### PR TITLE
Use scan config name from url param

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -417,6 +417,7 @@ const rescore = {
     artefactExtraId,
     cveRescoringRuleSetName,
     types,
+    scanConfigName,
   }) => {
     const url = new URL(routes.rescore)
     appendPresentParams(url, {
@@ -428,13 +429,17 @@ const rescore = {
       artefactType,
       artefactExtraId: JSON.stringify(artefactExtraId),
       cveRescoringRuleSetName,
+      scanConfigName,
     })
     types?.map((type) => appendPresentParams(url, {type}))
 
     return await _toJson(withAuth(url))
   },
-  create: async ({rescorings}) => {
+  create: async ({rescorings, scanConfigName}) => {
     const url = new URL(routes.rescore)
+    appendPresentParams(url, {
+      scanConfigName,
+    })
 
     const resp = await withAuth(url, {
       method: 'POST',
@@ -455,9 +460,12 @@ const rescore = {
 
     return true
   },
-  delete: async ({id}) => {
+  delete: async ({id, scanConfigName}) => {
     const url = new URL(routes.rescore)
-    appendPresentParams(url, {id})
+    appendPresentParams(url, {
+      id,
+      scanConfigName,
+    })
 
     const resp = await withAuth(url, {
       method: 'DELETE',

--- a/src/components/compliance/Compliance.js
+++ b/src/components/compliance/Compliance.js
@@ -39,6 +39,7 @@ import SendIcon from '@mui/icons-material/Send'
 import { useSnackbar } from 'notistack'
 import { useTheme } from '@emotion/react'
 
+import { SearchParamContext } from '../../App'
 import { artefactsQueryMetadata } from '../../api'
 import { useFetchBom, useFetchScanConfigurations } from '../../api/useFetch'
 import {
@@ -865,10 +866,16 @@ const Artefacts = ({
 }) => {
   const { enqueueSnackbar } = useSnackbar()
 
+  const searchParamContext = React.useContext(SearchParamContext)
+  const scanConfigName = searchParamContext.get('scanConfigName')
   const [artefactMetadata, setArtefactMetadata] = React.useState()
   const [isLoading, setIsLoading] = React.useState(true)
   const [isError, setIsError] = React.useState(false)
   const [scanConfigs] = useFetchScanConfigurations()
+
+  const scanConfig = scanConfigName
+    ? scanConfigs?.find((scanConfig) => scanConfig.name === scanConfigName)
+    : scanConfigs?.length === 1 ? scanConfigs[0] : null
 
   const fetchQueryMetadata = React.useCallback(async (enableCache) => {
     try {
@@ -967,7 +974,7 @@ const Artefacts = ({
         type={type}
         handleClose={() => setMountRescoring(false)}
         fetchComplianceData={fetchQueryMetadata}
-        scanConfig={scanConfigs?.length === 1 ? scanConfigs[0] : null}
+        scanConfig={scanConfig}
       />
     }
     <Header

--- a/src/components/dependencies/ComplianceCells.js
+++ b/src/components/dependencies/ComplianceCells.js
@@ -229,7 +229,7 @@ const ComplianceCell = ({
   complianceSummaryFetchDetails,
   complianceDataFetchDetails,
   fetchComplianceSummary,
-  scanConfigs,
+  scanConfig,
 }) => {
   const {complianceSummary, isSummaryLoading, isSummaryError} = complianceSummaryFetchDetails
   const {complianceData, isDataLoading, isDataError} = complianceDataFetchDetails
@@ -276,21 +276,12 @@ const ComplianceCell = ({
   const lastBdbaScan = findLastScan(complianceFiltered, datasources.BDBA)
   const lastMalwareScan = findLastScan(complianceFiltered, datasources.CLAMAV)
 
-  const singleScanCfgOrNull = ({
-    scanCfgs,
-    complianceToolName,
-  }) => {
-    // only show the "shortcut" rescan button iff there is _one_ scan config and this scan config includes
-    // a certain configuration (otherwise, we're not able to determine the correct configs (i.e. bdba groups))
-    return scanCfgs?.length === 1 && complianceToolName in scanCfgs[0].config ? scanCfgs[0] : null
-  }
-
   return <TableCell>
     <Grid container direction='row-reverse' spacing={1}>
       <IssueChip
         component={component}
         artefact={artefact}
-        scanConfigs={scanConfigs}
+        scanConfig={scanConfig?.config && COMPLIANCE_TOOLS.ISSUE_REPLICATOR in scanConfig.config ? scanConfig : null}
       />
       {
         artefact.kind === ARTEFACT_KIND.RESOURCE && <BDBACell
@@ -300,7 +291,7 @@ const ComplianceCell = ({
           type={artefactMetadataTypes.LICENSE}
           severity={getMaxSeverity(artefactMetadataTypes.LICENSE)}
           lastScan={lastBdbaScan}
-          scanConfig={singleScanCfgOrNull({scanCfgs: scanConfigs, complianceToolName: COMPLIANCE_TOOLS.BDBA})}
+          scanConfig={scanConfig?.config && COMPLIANCE_TOOLS.BDBA in scanConfig.config ? scanConfig : null}
           fetchComplianceSummary={fetchComplianceSummary}
           isLoading={isDataLoading}
         />
@@ -318,7 +309,7 @@ const ComplianceCell = ({
           ocmNode={new OcmNode([component], artefact, ARTEFACT_KIND.RESOURCE)}
           ocmRepo={ocmRepo}
           metadataTypedef={findTypedefByName({name: artefactMetadataTypes.FINDING_MALWARE})}
-          scanConfig={singleScanCfgOrNull({scanCfgs: scanConfigs, complianceToolName: COMPLIANCE_TOOLS.CLAMAV})}
+          scanConfig={scanConfig?.config && COMPLIANCE_TOOLS.CLAMAV in scanConfig.config ? scanConfig : null}
           fetchComplianceSummary={fetchComplianceSummary}
           lastScan={lastMalwareScan}
           severity={getMaxSeverity(artefactMetadataTypes.FINDING_MALWARE)}
@@ -347,7 +338,7 @@ const ComplianceCell = ({
           type={artefactMetadataTypes.VULNERABILITY}
           severity={getMaxSeverity(artefactMetadataTypes.VULNERABILITY)}
           lastScan={lastBdbaScan}
-          scanConfig={singleScanCfgOrNull({scanCfgs: scanConfigs, complianceToolName: COMPLIANCE_TOOLS.BDBA})}
+          scanConfig={scanConfig?.config && COMPLIANCE_TOOLS.BDBA in scanConfig.config ? scanConfig : null}
           fetchComplianceSummary={fetchComplianceSummary}
           isLoading={isDataLoading}
         />
@@ -363,7 +354,7 @@ ComplianceCell.propTypes = {
   complianceSummaryFetchDetails: PropTypes.object.isRequired,
   complianceDataFetchDetails: PropTypes.object.isRequired,
   fetchComplianceSummary: PropTypes.func.isRequired,
-  scanConfigs: PropTypes.arrayOf(PropTypes.object),
+  scanConfig: PropTypes.object,
 }
 
 

--- a/src/components/dependencies/ComplianceChips.js
+++ b/src/components/dependencies/ComplianceChips.js
@@ -305,23 +305,16 @@ GolangChip.propTypes = {
 const IssueChip = ({
   component,
   artefact,
-  scanConfigs,
+  scanConfig,
 }) => {
-  // only show issue cell iff there is _one_ scan config and this scan config includes an
-  // issue replicator configuration (otherwise, we're not able to determine a github repo url)
-  if (!(scanConfigs?.length === 1 && COMPLIANCE_TOOLS.ISSUE_REPLICATOR in scanConfigs[0].config)) return
-  const scanConfig = scanConfigs[0]
+  if (!scanConfig) return
 
-  if (scanConfig) {
-    // if artefact type filter is set, don't show license chip for types that are filtered out
-    const artefactTypes = scanConfig.config.issueReplicator.artefact_types
-      ? scanConfig.config.issueReplicator.artefact_types
-      : scanConfig.config.defaults.artefact_types
+  // if artefact type filter is set, don't show license chip for types that are filtered out
+  const artefactTypes = scanConfig.config.issueReplicator.artefact_types
+    ? scanConfig.config.issueReplicator.artefact_types
+    : scanConfig.config.defaults.artefact_types
 
-    if (artefactTypes && !artefactTypes.some((type) => type === artefact.type)) {
-      return null
-    }
-  }
+  if (artefactTypes && !artefactTypes.some((type) => type === artefact.type)) return
 
   const repoUrl = scanConfig.config.issueReplicator.github_issues_target_repository_url
   const issueState = encodeURIComponent('is:open')
@@ -372,7 +365,7 @@ IssueChip.displayName = 'IssueChip'
 IssueChip.propTypes = {
   component: PropTypes.object.isRequired,
   artefact: PropTypes.object.isRequired,
-  scanConfigs: PropTypes.arrayOf(PropTypes.object),
+  scanConfig: PropTypes.object,
 }
 
 export {

--- a/src/components/dependencies/Component.js
+++ b/src/components/dependencies/Component.js
@@ -435,12 +435,18 @@ const ComponentDetails = React.memo(
     complianceSummaryFetchDetails,
     fetchComplianceSummary,
   }) => {
+    const searchParamContext = React.useContext(SearchParamContext)
+    const scanConfigName = searchParamContext.get('scanConfigName')
     const [scanConfigs] = useFetchScanConfigurations()
     const [responsibleData, isResponsibleDataLoading, isResponsibleDataError] = useFetchComponentResponsibles({
       componentName: component.name,
       componentVersion: component.version,
       ocmRepo: ocmRepo,
     })
+
+    const scanConfig = scanConfigName
+      ? scanConfigs?.find((scanConfig) => scanConfig.name === scanConfigName)
+      : scanConfigs?.length === 1 ? scanConfigs[0] : null
 
     if (isComponentError) {
       return <Alert severity='error'>Unable to fetch Component</Alert>
@@ -453,7 +459,7 @@ const ComponentDetails = React.memo(
           ocmRepo={ocmRepo}
           complianceSummaryFetchDetails={complianceSummaryFetchDetails}
           fetchComplianceSummary={fetchComplianceSummary}
-          scanConfigs={scanConfigs}
+          scanConfig={scanConfig}
         />
       }
       <ComponentReferencedBy component={component} ocmRepo={ocmRepo}/>
@@ -518,7 +524,7 @@ const ArtefactDetails = ({
   complianceSummaryFetchDetails,
   complianceDataFetchDetails,
   fetchComplianceSummary,
-  scanConfigs,
+  scanConfig,
 }) => {
   if (artefacts.length === 0) return null
 
@@ -550,7 +556,7 @@ const ArtefactDetails = ({
                 complianceSummaryFetchDetails={complianceSummaryFetchDetails}
                 complianceDataFetchDetails={complianceDataFetchDetails}
                 fetchComplianceSummary={fetchComplianceSummary}
-                scanConfigs={scanConfigs}
+                scanConfig={scanConfig}
               />
             })
           }
@@ -568,7 +574,7 @@ ArtefactDetails.propTypes = {
   complianceSummaryFetchDetails: PropTypes.object.isRequired,
   complianceDataFetchDetails: PropTypes.object.isRequired,
   fetchComplianceSummary: PropTypes.func.isRequired,
-  scanConfigs: PropTypes.arrayOf(PropTypes.object),
+  scanConfig: PropTypes.object,
 }
 
 
@@ -577,7 +583,7 @@ const Artefacts = ({
   ocmRepo,
   complianceSummaryFetchDetails,
   fetchComplianceSummary,
-  scanConfigs,
+  scanConfig,
 }) => {
   const [complianceData, isDataLoading, isDataError] = useFetchQueryMetadata({
     artefacts: [{
@@ -636,7 +642,7 @@ const Artefacts = ({
       complianceSummaryFetchDetails={complianceSummaryFetchDetails}
       complianceDataFetchDetails={complianceDataFetchDetails}
       fetchComplianceSummary={fetchComplianceSummary}
-      scanConfigs={scanConfigs}
+      scanConfig={scanConfig}
     />
     <ArtefactDetails
       component={component}
@@ -646,7 +652,7 @@ const Artefacts = ({
       complianceSummaryFetchDetails={complianceSummaryFetchDetails}
       complianceDataFetchDetails={complianceDataFetchDetails}
       fetchComplianceSummary={fetchComplianceSummary}
-      scanConfigs={scanConfigs}
+      scanConfig={scanConfig}
     />
     <ComponentReferences
       component={component}
@@ -660,7 +666,7 @@ Artefacts.propTypes = {
   ocmRepo: PropTypes.string,
   complianceSummaryFetchDetails: PropTypes.object.isRequired,
   fetchComplianceSummary: PropTypes.func.isRequired,
-  scanConfigs: PropTypes.arrayOf(PropTypes.object),
+  scanConfig: PropTypes.object,
 }
 
 
@@ -671,7 +677,7 @@ const ArtefactTableRow = ({
   complianceSummaryFetchDetails,
   complianceDataFetchDetails,
   fetchComplianceSummary,
-  scanConfigs,
+  scanConfig,
 }) => {
   return <TableRow
     key={generateArtefactID(artefact)}
@@ -687,7 +693,7 @@ const ArtefactTableRow = ({
         complianceSummaryFetchDetails={complianceSummaryFetchDetails}
         complianceDataFetchDetails={complianceDataFetchDetails}
         fetchComplianceSummary={fetchComplianceSummary}
-        scanConfigs={scanConfigs}
+        scanConfig={scanConfig}
       />
     </FeatureDependent>
   </TableRow>
@@ -700,7 +706,7 @@ ArtefactTableRow.propTypes = {
   complianceSummaryFetchDetails: PropTypes.object.isRequired,
   complianceDataFetchDetails: PropTypes.object.isRequired,
   fetchComplianceSummary: PropTypes.func.isRequired,
-  scanConfigs: PropTypes.arrayOf(PropTypes.object),
+  scanConfig: PropTypes.object,
 }
 
 

--- a/src/components/dependencies/RescoringModal.js
+++ b/src/components/dependencies/RescoringModal.js
@@ -972,6 +972,7 @@ const ApplicableRescorings = ({
   isAuthenticated,
   expanded,
   rescoringFeature,
+  scanConfig,
 }) => {
   if (rescoring.applicable_rescorings.length === 0) {
     // if all applicable rescorings were deleted, don't show collapse anymore
@@ -982,6 +983,7 @@ const ApplicableRescorings = ({
     try {
       await rescore.delete({
         id: applicableRescoring.id,
+        scanConfigName: scanConfig?.name,
       })
       if (fetchComplianceSummary) {
         // function is not defined when invoked from compliance tab
@@ -1122,6 +1124,7 @@ ApplicableRescorings.propTypes = {
   isAuthenticated: PropTypes.bool.isRequired,
   expanded: PropTypes.bool.isRequired,
   rescoringFeature: PropTypes.object,
+  scanConfig: PropTypes.object,
 }
 
 
@@ -1604,6 +1607,7 @@ const RescoringContentTableRow = ({
       isAuthenticated={isAuthenticated}
       expanded={expanded}
       rescoringFeature={rescoringFeature}
+      scanConfig={scanConfig}
     />
   </>
 }
@@ -2057,7 +2061,8 @@ const Rescoring = ({
                 artefactMetadataTypes.VULNERABILITY,
                 artefactMetadataTypes.LICENSE,
                 artefactMetadataTypes.FINDING_MALWARE,
-              ]
+              ],
+              scanConfigName: scanConfig?.name,
             }),
             ocmNode,
           )
@@ -2171,6 +2176,7 @@ const Rescore = ({
   scope,
   fetchComplianceData,
   fetchComplianceSummary,
+  scanConfig,
 }) => {
   const [isLoading, setIsLoading] = React.useState(false)
 
@@ -2300,6 +2306,7 @@ const Rescore = ({
               rescorings: {
                 entries: serialisedRescorings,
               },
+              scanConfigName: scanConfig?.name,
             })
           }
         } catch (error) {
@@ -2366,6 +2373,7 @@ Rescore.propTypes = {
   scope: PropTypes.string.isRequired,
   fetchComplianceData: PropTypes.func,
   fetchComplianceSummary: PropTypes.func,
+  scanConfig: PropTypes.object,
 }
 
 
@@ -2741,6 +2749,7 @@ const RescoringModal = ({
               scope={scope}
               fetchComplianceData={fetchComplianceData}
               fetchComplianceSummary={fetchComplianceSummary}
+              scanConfig={scanConfig}
             />
           </Box>
         </Grid>


### PR DESCRIPTION
**What this PR does / why we need it**:
If the URL parameter `scanConfigName` is present, use it to determine the scan configure which is to-be used. Otherwise, in case only one such config exists, use this config, else disable dependent features.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
