### PR TITLE
Add option to display "raw" component-descriptor

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -125,6 +125,7 @@ const ocmComponent = async ({
   ocmRepoUrl,
   version,
   versionFilter,
+  raw=false,
 }) => {
   const url = new URL(routes.ocm.component.base)
   appendPresentParams(url, {
@@ -132,6 +133,7 @@ const ocmComponent = async ({
     ocm_repo_url: ocmRepoUrl,
     version: version,
     version_filter: versionFilter,
+    raw: raw,
   })
 
   const resp = await withAuth(url)

--- a/src/api/useFetch.js
+++ b/src/api/useFetch.js
@@ -267,6 +267,7 @@ const useFetchComponentDescriptor = ({
   ocmRepoUrl,
   version,
   versionFilter,
+  raw=false,
 }) => {
   const [componentDescriptor, setComponentDescriptor] = React.useState()
   const [isError, setIsError] = React.useState()
@@ -292,6 +293,7 @@ const useFetchComponentDescriptor = ({
           ocmRepoUrl,
           version,
           versionFilter,
+          raw,
         })
 
         if (mounted) {

--- a/src/components/ComponentView.js
+++ b/src/components/ComponentView.js
@@ -88,6 +88,7 @@ export const ComponentView = ({
         componentDescriptor={componentDescriptor}
         isLoading={isLoading}
         ocmRepo={ocmRepo}
+        versionFilter={componentMeta.versionFilter}
       />
     }
   </Box>

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -51,6 +51,7 @@ export const ComponentTabs = ({
   componentDescriptor,
   isLoading,
   ocmRepo,
+  versionFilter,
 }) => {
   const featureRegistrationContext = React.useContext(FeatureRegistrationContext)
   const [upgradePRsFeature, setUpgradePRsFeature] = React.useState()
@@ -147,6 +148,8 @@ export const ComponentTabs = ({
       <CdTab
         componentDescriptor={componentDescriptor}
         isLoading={isLoading}
+        ocmRepo={ocmRepo}
+        versionFilter={versionFilter}
       />
     </TabPanel>
     <FeatureDependent requiredFeatures={[features.UPGRADE_PRS]}>
@@ -194,4 +197,5 @@ ComponentTabs.propTypes = {
   componentDescriptor: PropTypes.object,
   isLoading: PropTypes.bool.isRequired,
   ocmRepo: PropTypes.string,
+  versionFilter: PropTypes.string,
 }

--- a/src/components/cdTab.js
+++ b/src/components/cdTab.js
@@ -1,35 +1,168 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import Grid from '@mui/material/Grid'
-import { Skeleton } from '@mui/material'
+import {
+  Box,
+  FormControlLabel,
+  FormGroup,
+  Switch,
+  Tooltip,
+} from '@mui/material'
 
 import MultilineTextViewer from './util/MultilineTextViewer'
+import { useFetchComponentDescriptor } from '../api/useFetch'
+import CenteredSpinner from './util/CenteredSpinner'
+import { SearchParamContext } from '../App'
 import { toYamlString } from '../util'
+
+
+const FetchAndView = ({
+  componentName,
+  componentVersion,
+  ocmRepo,
+  versionFilter,
+  setRaw,
+  raw,
+}) => {
+  // eslint-disable-next-line no-unused-vars
+  const [componentDescriptor, isLoading, isError, error] = useFetchComponentDescriptor({
+    componentName: componentName,
+    ocmRepoUrl: ocmRepo,
+    version: componentVersion,
+    versionFilter: versionFilter,
+    raw: true,
+  })
+
+  React.useEffect(() => {
+    setRaw(JSON.stringify(componentDescriptor, null, 2))
+  }, [setRaw, componentDescriptor])
+
+  return <MultilineTextViewer
+    text={raw}
+  />
+}
+FetchAndView.displayName = 'FetchAndView'
+FetchAndView.propTypes = {
+  componentName: PropTypes.string.isRequired,
+  componentVersion: PropTypes.string.isRequired,
+  ocmRepo: PropTypes.string,
+  versionFilter: PropTypes.string,
+  setRaw: PropTypes.func.isRequired,
+  raw: PropTypes.string,
+}
+
+
+const Options = ({
+  isLoading,
+  showRaw,
+  setShowRaw,
+}) => {
+  return <Box>
+    <FormGroup>
+      <FormControlLabel
+        control={
+          <Tooltip
+            title='Raw document as retrieved from OCM repository, without (de)serialisation'
+          >
+            <Switch
+              checked={showRaw}
+              // eslint-disable-next-line no-unused-vars
+              onChange={(event) => setShowRaw((prev) => !prev)}
+              disabled={isLoading}
+            />
+          </Tooltip>
+        }
+        label='show raw'
+      />
+    </FormGroup>
+  </Box>
+}
+Options.displayName = 'Options'
+Options.propTypes = {
+  isLoading: PropTypes.bool,
+  showRaw: PropTypes.bool.isRequired,
+  setShowRaw: PropTypes.func.isRequired,
+}
+
+
+const ComponentDescriptor = ({
+  showRaw,
+  raw,
+  componentDescriptor,
+  setRaw,
+  ocmRepo,
+  versionFilter,
+}) => {
+  return (showRaw && !raw) // prevent re-fetching if raw cd is present already
+    ? <FetchAndView
+      componentName={componentDescriptor.component.name}
+      componentVersion={componentDescriptor.component.version}
+      ocmRepo={ocmRepo}
+      versionFilter={versionFilter}
+      setRaw={setRaw}
+      raw={raw}
+    />
+    : <MultilineTextViewer
+      text={
+        showRaw
+          ? raw
+          : toYamlString(componentDescriptor)
+      }
+    />
+}
+ComponentDescriptor.displayName = 'ComponentDescriptor'
+ComponentDescriptor.propTypes = {
+  showRaw: PropTypes.bool.isRequired,
+  raw: PropTypes.string,
+  setRaw: PropTypes.func.isRequired,
+  componentDescriptor: PropTypes.object,
+  ocmRepo: PropTypes.string,
+  versionFilter: PropTypes.string,
+}
 
 
 export const CdTab = ({
   componentDescriptor,
   isLoading,
+  ocmRepo,
+  versionFilter,
 }) => {
-  if (!isLoading) return <MultilineTextViewer text={toYamlString(componentDescriptor)}/>
+  const searchParamContext = React.useContext(SearchParamContext)
 
-  return <Grid container>
+  const [showRaw, setShowRaw] = React.useState(searchParamContext.get('rawCd') === 'true')
+  const [raw, setRaw] = React.useState()
+
+  React.useEffect(() => {
+    searchParamContext.update({'rawCd': showRaw})
+  }, [showRaw])
+
+  return <Box
+    display='flex'
+    flexDirection='column'
+  >
+    <Options
+      isLoading={isLoading}
+      showRaw={showRaw}
+      setShowRaw={setShowRaw}
+    />
     {
-      Array.from(Array(30).keys()).map(e => {
-        return <Grid
-          item
-          xs={6}
-          key={e}
-        >
-          <Skeleton/>
-        </Grid>
-      })
+      isLoading
+        ? <CenteredSpinner/>
+        : <ComponentDescriptor
+          showRaw={showRaw}
+          raw={raw}
+          setRaw={setRaw}
+          componentDescriptor={componentDescriptor}
+          ocmRepo={ocmRepo}
+          versionFilter={versionFilter}
+        />
     }
-  </Grid>
+  </Box>
 }
 CdTab.displayName = 'CdTab'
 CdTab.propTypes = {
   componentDescriptor: PropTypes.object,
   isLoading: PropTypes.bool,
+  ocmRepo: PropTypes.string,
+  versionFilter: PropTypes.string,
 }


### PR DESCRIPTION
Useful for debugging.
Will also bypass delivery-service cache mechanism.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
