### PR TITLE
Update branding to ODG

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 # use local api for local development by default
-REACT_APP_DASHBOARD_TITLE='Delivery Dashboard'
+REACT_APP_DASHBOARD_TITLE='Open Delivery Gear'
 REACT_APP_DELIVERY_SERVICE_API_URL=http://localhost:5000
 REACT_APP_BUILD_VERSION=dev-build
 REACT_APP_ISSUE_BODY_MARKDOWN_PARSING=true

--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,4 @@
-REACT_APP_DASHBOARD_TITLE='Delivery Dashboard'
+REACT_APP_DASHBOARD_TITLE='Open Delivery Gear'
 REACT_APP_BUILD_VERSION=$build_version
 # REACT_APP_DELIVERY_SERVICE_API_URL=https://your.delivery-service.url
 # hint: injected during deployment

--- a/src/App.js
+++ b/src/App.js
@@ -69,6 +69,13 @@ const App = () => {
     setThemeMode(!themeMode)
   }
 
+  const OdgLogoColors = {
+    light: '#019aff',
+    middle: '#0c61f1',
+    dark: '#0e35c6',
+  }
+  Object.freeze(OdgLogoColors)
+
   const { palette } = createTheme()
   const theme = createTheme({
     palette: {
@@ -76,7 +83,7 @@ const App = () => {
         main: '#424242',
       },
       secondary: {
-        main: '#0b8062',
+        main: themeMode ? OdgLogoColors.light : OdgLogoColors.dark,
       },
       background: {
         main: themeMode ? '#20000000' : '#ffffff',
@@ -147,6 +154,11 @@ const App = () => {
     dependentComponentOverview: {
       color: themeMode ? '#99ff9980' : '#99ff9980'
     },
+    odg: {
+      light: OdgLogoColors.light,
+      middle: OdgLogoColors.middle,
+      dark: OdgLogoColors.dark,
+    }
   })
 
   const configValue = {

--- a/src/consts.js
+++ b/src/consts.js
@@ -1,4 +1,4 @@
-export const DASHBOARD_TITLE = 'Delivery Dashboard'
+export const DASHBOARD_TITLE = 'Open Delivery Gear'
 
 export const tabConfig = {
   BOM: {

--- a/src/landing.js
+++ b/src/landing.js
@@ -334,7 +334,13 @@ const SpecialComponents = () => {
       </Stack>
     </DragDropContext>
     <Fab
-      style={{backgroundColor: theme.dependentComponentOverview.color, color: theme.bomButton.color, position: 'fixed', bottom: '1.5rem', right: '1.5rem'}}
+      style={{
+        backgroundColor: theme.odg.light,
+        color: 'white',
+        position: 'fixed',
+        bottom: '1.5rem',
+        right: '1.5rem',
+      }}
       onClick={handleOpenNewSpecialComponent}
     >
       <AddIcon/>

--- a/src/login.js
+++ b/src/login.js
@@ -131,7 +131,7 @@ const LoginPanelTop = () => {
       src={ODGLogo}
       alt='odg-logo'
     />
-    <Typography marginTop='1rem' variant='h5' color={theme.palette.secondary.main}>
+    <Typography marginTop='1rem' variant='h5' color={theme.odg.light}>
       {
         DASHBOARD_TITLE
       }


### PR DESCRIPTION
**What this PR does / why we need it**:
Use colors matching ODG logo and update title texts.

![Screenshot 2025-04-16 at 15 30 13](https://github.com/user-attachments/assets/4892800d-174c-4d24-8e82-39d3ea15592c)
![Screenshot 2025-04-16 at 15 30 34](https://github.com/user-attachments/assets/fe113927-7208-4009-9d34-c149309f3115)
![Screenshot 2025-04-16 at 15 32 00](https://github.com/user-attachments/assets/3f93f2e8-c9c1-49f8-adf6-fba029150608)
![Screenshot 2025-04-16 at 15 32 54](https://github.com/user-attachments/assets/7c864e1b-8a6f-4719-ada4-f370b1456de4)



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
ODG now uses bluish colors to better match ODG logo.
```
