### PR TITLE
Honour list of accepted JWT versions

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -8,6 +8,7 @@ import {
   isTokenExpired,
 } from './util'
 import {
+  ACCEPTED_JWT_VERSIONS,
   copyNotificationCfg,
   TOKEN_KEY,
 } from './consts'
@@ -38,7 +39,7 @@ const refreshToken = async () => {
       return
     }
 
-    if (!isTokenExpired(token)) {
+    if (ACCEPTED_JWT_VERSIONS.includes(token.version) && !isTokenExpired(token)) {
       // this is the case if another request has also triggered a token refresh and the token has
       // already been updated -> nothing to do here
       return

--- a/src/consts.js
+++ b/src/consts.js
@@ -1,5 +1,8 @@
 export const DASHBOARD_TITLE = 'Open Delivery Gear'
 
+export const ACCEPTED_JWT_VERSIONS = ['v2']
+Object.freeze(ACCEPTED_JWT_VERSIONS)
+
 export const tabConfig = {
   BOM: {
     id: 'bom',


### PR DESCRIPTION
**What this PR does / why we need it**:
If the user has a token with an invalid JWT version (e.g. outdated), he will be logged-out and redirected to the login screen.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Accepted JWT versions are now honoured in delivery-dashboard
```
