### PR TITLE
fix: Be more defensive when reading properties of findings

### DIFF
--- a/src/rescoring.js
+++ b/src/rescoring.js
@@ -2179,7 +2179,7 @@ const RescoringContent = ({
 
     const ipAccess = {
       [orderAttributes.SUBJECT]: rescoring.finding.package_name + rescoring.finding.package_versions,
-      [orderAttributes.FINDING]: rescoring.finding.license.name,
+      [orderAttributes.FINDING]: rescoring.finding.license?.name,
       [orderAttributes.SPRINT]: rescoring.sprint ? new Date(rescoring.sprint.end_date) : new Date(8640000000000000),
       [orderAttributes.CURRENT]: categoriseRescoringProposal({rescoring, findingCfg}).value,
       [orderAttributes.RESCORED]: findCategorisationById({


### PR DESCRIPTION
The affected code path is always executed, independent of the actual active finding type. Hence, certain properties of the `finding` are not defined (in this case: `license`). Hence, be more defensive in case this property is `undefined`.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```bugfix user
Fixed a bug where the rescoring UI displayed an error because of an invalid variable access 
```
