### PR TITLE
fix: Only identify root component via ID and not via OCM repository

### DIFF
--- a/src/component/bom.js
+++ b/src/component/bom.js
@@ -60,7 +60,6 @@ import {
   componentPathQuery,
   enhanceComponentRefFromPath,
   normaliseExtraIdentity,
-  normaliseObject,
   trimComponentName,
   trimLongString,
   updatePathFromComponentRef,
@@ -1474,7 +1473,6 @@ const FetchDependenciesTab = React.memo(({
 
   const isParentComponent = (c) => {
     return c.name === component.name && c.version === component.version
-      && JSON.stringify(normaliseObject(c.repositoryContexts)) === JSON.stringify(normaliseObject(component.repositoryContexts))
   }
 
   const [components, state] = useFetchBom({


### PR DESCRIPTION
**What this PR does / why we need it**:
Due to caching hierarchy of OCM component descriptors in the Delivery-Service, it might happen that different Delivery-Service Pods will resolve the same OCM component from different OCM repositories in case the "auto" lookup is used. To prevent the root component from being displayed both at the top level and as one of its dependencies in that case, check only for a matching ID (name + version).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix user
Consistently highlight root OCM component and deduplicate with its dependencies
```
