### PR TITLE
Add `HTTPRoute` for delivery-dashboard as preparation for Gateway API

### DIFF
--- a/charts/delivery-dashboard/templates/service.yaml
+++ b/charts/delivery-dashboard/templates/service.yaml
@@ -13,3 +13,22 @@ spec:
     name: default
   selector:
     app: delivery-dashboard
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: delivery-dashboard
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+spec:
+  parentRefs:
+    - name: {{ default "open-delivery-gear" .Values.gatewayName }}
+  hostnames:
+    - {{ .Values.host }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: delivery-dashboard
+          port: {{ default 8080 .Values.servicePort }}

--- a/charts/delivery-dashboard/values.yaml
+++ b/charts/delivery-dashboard/values.yaml
@@ -3,6 +3,7 @@ image:
   repository: ~
   tag: ~
 envVars: []
+host: localhost
 ingress:
   hosts: []
   tlsHostNames: []

--- a/extension-definitions.yaml
+++ b/extension-definitions.yaml
@@ -17,6 +17,10 @@ installation:
       value: ${target_namespace}
       value_type: python-string-template
     - helm_chart_name: delivery-dashboard
+      helm_attribute: host
+      value: delivery-dashboard.${base_url}
+      value_type: python-string-template
+    - helm_chart_name: delivery-dashboard
       helm_attribute: ingress.hosts
       value:
         - delivery-dashboard.${base_url}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```noteworthy operator
The delivery-dashboard Helm chart now also includes a `HTTPRoute` as preparation for using the Gateway API
```
