### PR TITLE
Add `dora` feature to conditionally toggle visibility of Dora tab

### DIFF
--- a/src/component/tabs.js
+++ b/src/component/tabs.js
@@ -60,6 +60,7 @@ export const ComponentTabs = ({
   const [testsFeature, setTestsFeature] = React.useState()
   const [authFeature, setAuthFeature] = React.useState()
   const [findingCfgsFeature, setFindingCfgsFeature] = React.useState()
+  const [doraFeature, setDoraFeature] = React.useState()
 
   const searchParamContext = React.useContext(SearchParamContext)
 
@@ -120,6 +121,14 @@ export const ComponentTabs = ({
     })
   }, [featureRegistrationContext])
 
+  React.useEffect(() => {
+    return registerCallbackHandler({
+      featureRegistrationContext: featureRegistrationContext,
+      featureName: features.DORA,
+      callback: ({ feature }) => setDoraFeature(feature),
+    })
+  }, [featureRegistrationContext])
+
   const handleChange = (_, newView) => {
     searchParamContext.update({'view': newView})
   }
@@ -137,8 +146,7 @@ export const ComponentTabs = ({
     if (!testsFeature || testsFeature.isAvailable) yield tabConfig.TESTS
     if ((!authFeature || authFeature.isAvailable) && complianceTabIsRequired) yield tabConfig.COMPLIANCE
     if (!deliveryDbFeature || deliveryDbFeature.isAvailable) yield tabConfig.QUERY
-
-    yield tabConfig.DORA
+    if (!doraFeature || doraFeature.isAvailable) yield tabConfig.DORA
   }
 
   const tabs = [...iterTabs()]
@@ -213,14 +221,16 @@ export const ComponentTabs = ({
         </TabPanel>
       </FeatureDependent>
     }
-    <TabPanel value={searchParamContext.get('view')} index={tabConfig.DORA.id}>
-      {
-        isLoading ? <CenteredSpinner sx={{ height: '90vh' }} /> : <DoraTabWrapper
-          componentName={componentDescriptor.component.name}
-          specialComponentId={specialComponentId}
-        />
-      }
-    </TabPanel>
+    <FeatureDependent requiredFeatures={[features.DORA]}>
+      <TabPanel value={searchParamContext.get('view')} index={tabConfig.DORA.id}>
+        {
+          isLoading ? <CenteredSpinner sx={{ height: '90vh' }} /> : <DoraTabWrapper
+            componentName={componentDescriptor.component.name}
+            specialComponentId={specialComponentId}
+          />
+        }
+      </TabPanel>
+    </FeatureDependent>
     <TabPanel value={searchParamContext.get('view')} index={tabConfig.QUERY.id}>
       {isLoading ? <CenteredSpinner sx={{ height: '90vh' }} /> : (
         <MetadataBrowserTab

--- a/src/consts.js
+++ b/src/consts.js
@@ -107,6 +107,7 @@ export const features = {
   AUTHENTICATION: 'authentication',
   DELIVERY_DB: 'delivery-db',
   CLUSTER_ACCESS: 'cluster-access',
+  DORA: 'dora',
   PROFILES: 'profiles',
   TESTS: 'tests',
   OCM_REPOSITORY_CFGS: 'ocm-repository-cfgs',


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/open-component-model/delivery-dashboard/issues/437

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```noteworthy user
The DORA tab is now disabled by default and can be enabled using the `dora` property in the features-cfg
```
