### PR TITLE
feat: Add direct links to BlackDuck scans

### DIFF
--- a/src/component/bom.js
+++ b/src/component/bom.js
@@ -2415,7 +2415,7 @@ const RescoringCell = ({
               />
             }
             {
-              datasource === datasources.BLACKDUCK && lastScan?.data.hrefs.map(href => <ExternalReferenceButton
+              datasource === datasources.BLACKDUCK && lastScan?.data?.hrefs?.map(href => <ExternalReferenceButton
                 key={href}
                 href={href}
                 text='View in BlackDuck'


### PR DESCRIPTION
**What this PR does / why we need it**:
Similar to BDBA, add direct link to OCM artefact to jump into BlackDuck scan details (href is part of IP meta finding).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement user
BlackDuck direct links to scan details are now exposed via compliance view 
```
