### PR TITLE
Add Download SBOM button

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -158,6 +158,7 @@ export const routes = {
     base: api('components'),
     complianceSummary: () => `${routes.components.base}/compliance-summary`,
     diff: () => `${routes.components.base}/diff`,
+    sbom: () => `${routes.components.base}/sbom`,
   },
   component: (name) => `${routes.components.base}/${name}`,
   upgradePullRequests: () =>
@@ -460,12 +461,31 @@ const rescore = {
 }
 
 
+const componentSbom = async ({
+  componentName,
+  componentVersion,
+  ocmRepoUrl,
+}) => {
+  const url = new URL(routes.components.sbom())
+  appendPresentParams(url, {
+    component_name: componentName,
+    version: componentVersion,
+    ocm_repo_url: ocmRepoUrl,
+  })
+
+  const resp = await withAuth(url)
+  await raiseIfNotOk(resp)
+  return await resp.blob()
+}
+
+
 const components = {
   diff: componentsDiff,
   complianceSummary: componentsComplianceSummary,
   upgradePullRequests: componentUpgradePRs,
   ocmComponent: ocmComponent,
   componentDependencies: ocmComponentDependencies,
+  componentSbom: componentSbom,
   componentResponsibles: ocmComponentResponsibles,
   lastVersions: ocmComponentVersions,
 }

--- a/src/component/bom.js
+++ b/src/component/bom.js
@@ -1196,6 +1196,7 @@ const DependenciesTabHeader = React.memo(({
   specialComponentId,
   browserLocalOnly,
   defaultSearchValue,
+  extensionsCfg,
 }) => {
   const searchParamContext = React.useContext(SearchParamContext)
   const now = new Date()
@@ -1248,11 +1249,13 @@ const DependenciesTabHeader = React.memo(({
         ocmRepo={searchParamContext.get('ocmRepo')}
         isLoading={isComponentLoading}
       />
-      <DownloadSbom
-        component={component}
-        ocmRepo={searchParamContext.get('ocmRepo')}
-        isLoading={isComponentLoading}
-      />
+      {
+        extensionsCfg?.sbom_generator?.enabled && <DownloadSbom
+          component={component}
+          ocmRepo={searchParamContext.get('ocmRepo')}
+          isLoading={isComponentLoading}
+        />
+      }
     </Grid>
   </Grid>
 })
@@ -1267,6 +1270,7 @@ DependenciesTabHeader.propTypes = {
   specialComponentId: PropTypes.string,
   browserLocalOnly: PropTypes.bool,
   defaultSearchValue: PropTypes.string,
+  extensionsCfg: PropTypes.object,
 }
 
 
@@ -1384,6 +1388,7 @@ export const BomTab = React.memo(({
       specialComponentId={specialComponentId}
       browserLocalOnly={browserLocalOnly}
       defaultSearchValue={searchQuery}
+      extensionsCfg={extensionsCfg}
     />
     <div style={{ padding: '0.5em' }} />
     {

--- a/src/component/bom.js
+++ b/src/component/bom.js
@@ -1243,7 +1243,7 @@ const DependenciesTabHeader = React.memo(({
         }
       </FeatureDependent>
     </Grid>
-    <Grid item width='25%' display='flex' justifyContent='right' flexDirection='row' gap={1}>
+    <Grid item width='27%' display='flex' justifyContent='right' flexDirection='row' gap={1}>
       <DownloadBom
         component={component}
         ocmRepo={searchParamContext.get('ocmRepo')}

--- a/src/component/bom.js
+++ b/src/component/bom.js
@@ -68,7 +68,6 @@ import {
   ExtraIdentityHover,
   matchObjectWithSearchQuery,
   shortenComponentName,
-  downloadObject,
 } from '../util'
 import ExtraWideTooltip from '../util/extraWideTooltip'
 import FeatureDependent from '../util/featureDependent'
@@ -96,6 +95,7 @@ import { OcmNode } from '../ocm/iter'
 import { artefactMetadataFilter } from '../ocm/util'
 import { MetadataViewerPopover, artefactMetadataTypes, datasources } from '../ocm/model'
 import { components, routes } from '../api'
+import { DownloadBom } from '../util/downloadButtons'
 import { SprintInfo } from '../util/sprint'
 import ErrorBoundary from '../util/errorBoundary'
 import { VersionOverview, evaluateVersionMatch } from '../util/versionOverview'
@@ -1147,59 +1147,6 @@ const LoadingDependencies = () => {
       <LoadingComponents loadingComponentsCount={loadingComponentsCount}/>
     </Stack>
   </Box>
-}
-
-const bomCache = {}
-
-const DownloadBom = ({
-  component,
-  ocmRepo,
-  isLoading,
-}) => {
-  const theme = useTheme()
-
-  const handleClick = async () => {
-    const key = `${component.name}:${component.version}`
-    let dependencies = null
-    if (!bomCache[key]) {
-      bomCache[key] = await components.componentDependencies({
-        componentName: component.name,
-        componentVersion: component.version,
-        ocmRepoUrl: ocmRepo,
-        populate: 'all',
-      })
-    }
-    dependencies = bomCache[key]
-
-    const blob = new Blob([JSON.stringify(dependencies)], {
-      type: 'application/json',
-    })
-
-    const fname = `${component.name ? component.name : component.target}-bom.json`
-
-    downloadObject({
-      obj: blob,
-      fname: fname,
-    })
-  }
-
-  return <Button
-    startIcon={<CloudDownloadIcon />}
-    onClick={handleClick}
-    variant='outlined'
-    style={{
-      color: isLoading ? 'grey' : theme.bomButton.color,
-    }}
-    disabled={isLoading}
-  >
-    download bom
-  </Button>
-}
-DownloadBom.displayName = 'DownloadBom'
-DownloadBom.propTypes = {
-  component: PropTypes.object,
-  ocmRepo: PropTypes.string,
-  isLoading: PropTypes.bool.isRequired,
 }
 
 const ComponentSearch = ({

--- a/src/component/bom.js
+++ b/src/component/bom.js
@@ -9,7 +9,6 @@ import {
   Avatar,
   Badge,
   Box,
-  Button,
   capitalize,
   Chip,
   CircularProgress,
@@ -94,8 +93,8 @@ import { RescoringModal } from '../rescoring'
 import { OcmNode } from '../ocm/iter'
 import { artefactMetadataFilter } from '../ocm/util'
 import { MetadataViewerPopover, artefactMetadataTypes, datasources } from '../ocm/model'
-import { components, routes } from '../api'
-import { DownloadBom } from '../util/downloadButtons'
+import { routes } from '../api'
+import { DownloadBom, DownloadSbom } from '../util/downloadButtons'
 import { SprintInfo } from '../util/sprint'
 import ErrorBoundary from '../util/errorBoundary'
 import { VersionOverview, evaluateVersionMatch } from '../util/versionOverview'
@@ -1206,7 +1205,7 @@ const DependenciesTabHeader = React.memo(({
     spacing={3}
     alignItems='center'
   >
-    <Grid item width='50%'>
+    <Grid item width='40%'>
       <ComponentSearch
         updateSearchQuery={updateSearchQuery}
         defaultValue={defaultSearchValue}
@@ -1243,8 +1242,13 @@ const DependenciesTabHeader = React.memo(({
         }
       </FeatureDependent>
     </Grid>
-    <Grid item width='17%' display='flex' justifyContent='right' flexDirection='column'>
+    <Grid item width='25%' display='flex' justifyContent='right' flexDirection='row' gap={1}>
       <DownloadBom
+        component={component}
+        ocmRepo={searchParamContext.get('ocmRepo')}
+        isLoading={isComponentLoading}
+      />
+      <DownloadSbom
         component={component}
         ocmRepo={searchParamContext.get('ocmRepo')}
         isLoading={isComponentLoading}

--- a/src/util/downloadButtons.js
+++ b/src/util/downloadButtons.js
@@ -40,7 +40,7 @@ export const DownloadBom = ({ component, ocmRepo, isLoading }) => {
     <Button
       startIcon={<CloudDownloadIcon />}
       onClick={handleClick}
-      variant="outlined"
+      variant='outlined'
       style={{
         color: isLoading ? 'grey' : theme.bomButton.color,
       }}
@@ -85,7 +85,7 @@ export const DownloadSbom = ({ component, ocmRepo, isLoading }) => {
     <Button
       startIcon={<CloudDownloadIcon />}
       onClick={handleClick}
-      variant="outlined"
+      variant='outlined'
       style={{
         color: isLoading ? 'grey' : theme.bomButton.color,
       }}

--- a/src/util/downloadButtons.js
+++ b/src/util/downloadButtons.js
@@ -57,3 +57,47 @@ DownloadBom.propTypes = {
   ocmRepo: PropTypes.string,
   isLoading: PropTypes.bool.isRequired,
 }
+
+const sbomCache = {}
+
+export const DownloadSbom = ({ component, ocmRepo, isLoading }) => {
+  const theme = useTheme()
+
+  const handleClick = async () => {
+    const key = `${component.name}:${component.version}`
+    if (!sbomCache[key]) {
+      sbomCache[key] = await components.componentSbom({
+        componentName: component.name,
+        componentVersion: component.version,
+        ocmRepoUrl: ocmRepo,
+      })
+    }
+
+    const fname = `${component.name ? component.name : component.target}_${component.version}.sbom.tar`
+
+    downloadObject({
+      obj: sbomCache[key],
+      fname: fname,
+    })
+  }
+
+  return (
+    <Button
+      startIcon={<CloudDownloadIcon />}
+      onClick={handleClick}
+      variant="outlined"
+      style={{
+        color: isLoading ? 'grey' : theme.bomButton.color,
+      }}
+      disabled={isLoading}
+    >
+      download sbom
+    </Button>
+  )
+}
+DownloadSbom.displayName = 'DownloadSbom'
+DownloadSbom.propTypes = {
+  component: PropTypes.object,
+  ocmRepo: PropTypes.string,
+  isLoading: PropTypes.bool.isRequired,
+}

--- a/src/util/downloadButtons.js
+++ b/src/util/downloadButtons.js
@@ -1,0 +1,59 @@
+import React from 'react'
+
+import { Button } from '@mui/material'
+import CloudDownloadIcon from '@mui/icons-material/CloudDownload'
+
+import PropTypes from 'prop-types'
+
+import { useTheme } from '@emotion/react'
+
+import { downloadObject } from '../util'
+import { components } from '../api'
+
+const bomCache = {}
+
+export const DownloadBom = ({ component, ocmRepo, isLoading }) => {
+  const theme = useTheme()
+
+  const handleClick = async () => {
+    const key = `${component.name}:${component.version}`
+    if (!bomCache[key]) {
+      bomCache[key] = await components.componentDependencies({
+        componentName: component.name,
+        componentVersion: component.version,
+        ocmRepoUrl: ocmRepo,
+        populate: 'all',
+      })
+    }
+
+    const blob = new Blob([JSON.stringify(bomCache[key])], {
+      type: 'application/json',
+    })
+
+    downloadObject({
+      obj: blob,
+      fname: `${component.name ? component.name : component.target}-bom.json`,
+    })
+  }
+
+  return (
+    <Button
+      startIcon={<CloudDownloadIcon />}
+      onClick={handleClick}
+      variant="outlined"
+      style={{
+        color: isLoading ? 'grey' : theme.bomButton.color,
+      }}
+      disabled={isLoading}
+    >
+      download bom
+    </Button>
+  )
+}
+
+DownloadBom.displayName = 'DownloadBom'
+DownloadBom.propTypes = {
+  component: PropTypes.object,
+  ocmRepo: PropTypes.string,
+  isLoading: PropTypes.bool.isRequired,
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Following the introduction of the ODG SBOM generation extension, this PR adds a Download SBOM button to the UI.

**Which issue(s) this PR fixes**:
Fixes https://github.com/open-component-model/open-delivery-gear/issues/33

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```feature user
Add Download SBOM button
```
