### PR TITLE
Also honour explicit OCM repo in component diff and artefact download

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -285,11 +285,13 @@ const ocmComponentVersions = async ({
 const componentUpgradePRs = async ({
   componentName,
   state,
+  ocmRepo,
 }) => {
   const url = new URL(routes.upgradePullRequests())
   appendPresentParams(url, {
     componentName,
     state,
+    ocmRepo,
   })
 
   return await _toJson(withAuth(url))

--- a/src/component/bom.js
+++ b/src/component/bom.js
@@ -795,7 +795,10 @@ const ArtefactTableRow = ({
 }) => {
   return <TableRow sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
     <IconCell artefact={ocmNode.artefact}/>
-    <ArtefactCell ocmNode={ocmNode}/>
+    <ArtefactCell
+      ocmNode={ocmNode}
+      ocmRepo={ocmRepo}
+    />
     <FeatureDependent requiredFeatures={[features.DELIVERY_DB]}>
       {
         findingCfgs.length > 0 && <ComplianceCell
@@ -2154,6 +2157,7 @@ ComplianceCell.propTypes = {
 
 const ArtefactCell = ({
   ocmNode,
+  ocmRepo,
 }) => {
   const component = ocmNode.component
   const artefact = ocmNode.artefact
@@ -2166,6 +2170,7 @@ const ArtefactCell = ({
       version: artefact.version,
       ...artefact.extraIdentity
     }),
+    ocm_repository: ocmRepo,
     unzip: 'true',
   })
 
@@ -2246,6 +2251,7 @@ const ArtefactCell = ({
 ArtefactCell.displayName = 'ArtefactCell'
 ArtefactCell.propTypes = {
   ocmNode: PropTypes.instanceOf(OcmNode).isRequired,
+  ocmRepo: PropTypes.string,
 }
 
 

--- a/src/component/diff.js
+++ b/src/component/diff.js
@@ -785,6 +785,7 @@ const FetchUpgradePullRequests = ({
   setIsError,
   componentName,
   prState,
+  ocmRepo,
 }) => {
   React.useEffect(() => {
     setIsLoading(true)
@@ -793,6 +794,7 @@ const FetchUpgradePullRequests = ({
         const prs = await components.upgradePullRequests({
           componentName: componentName,
           state: prState,
+          ocmRepo: ocmRepo,
         })
         setPullRequests(prs)
         setIsLoading(false)
@@ -815,6 +817,7 @@ const FetchUpgradePullRequests = ({
   }, [
     componentName,
     prState,
+    ocmRepo,
     setIsError,
     setIsLoading,
     setPullRequests,
@@ -828,6 +831,7 @@ FetchUpgradePullRequests.propTypes = {
   setIsError: PropTypes.func.isRequired,
   componentName: PropTypes.string.isRequired,
   prState: PropTypes.string.isRequired,
+  ocmRepo: PropTypes.string,
 }
 
 
@@ -849,6 +853,7 @@ export const ComponentDiffTab = React.memo(({
   const [prs, prState] = useFetchUpgradePRs({
     componentName: component.name,
     state: pullRequestsStates.OPEN,
+    ocmRepo: ocmRepo,
   })
 
   const [mountFetchClosedPrs, setMountFetchClosedPrs] = React.useState(false)
@@ -982,6 +987,7 @@ export const ComponentDiffTab = React.memo(({
         setIsError={setClosedPrsError}
         componentName={component.name}
         prState={pullRequestsStates.CLOSED}
+        ocmRepo={ocmRepo}
       />
     }
     <Typography>Compare Component Versions</Typography>

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -304,13 +304,16 @@ const useFetchProfiles = () => {
 const useFetchUpgradePRs = ({
   componentName,
   state,
+  ocmRepo,
 }) => {
   const params = React.useMemo(() => ({
     componentName,
     state,
+    ocmRepo,
   }), [
     componentName,
     state,
+    ocmRepo,
   ])
 
   return _useFetch({


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/open-component-model/open-delivery-gear/issues/44

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix user
The OCM component diff tab and the artefact download now also correctly honour an explicitly configured OCM repository
```
