### PR TITLE
Add SBoM download popover

### DIFF
--- a/src/component/bom.js
+++ b/src/component/bom.js
@@ -94,11 +94,12 @@ import { OcmNode } from '../ocm/iter'
 import { artefactMetadataFilter } from '../ocm/util'
 import { MetadataViewerPopover, artefactMetadataTypes, datasources } from '../ocm/model'
 import { routes } from '../api'
-import { DownloadBom, DownloadSbom } from '../util/downloadButtons'
+import { DownloadBom, OpenSbomPopoverButton } from '../util/downloadButtons'
 import { SprintInfo } from '../util/sprint'
 import ErrorBoundary from '../util/errorBoundary'
 import { VersionOverview, evaluateVersionMatch } from '../util/versionOverview'
 import TriggerComplianceToolButton from '../util/triggerComplianceToolButton'
+import SbomDownloadPopover from '../util/sbomDownloadPopover'
 import {
   categorisationValueToColor,
   categorisationValueToIndicator,
@@ -1199,6 +1200,7 @@ const DependenciesTabHeader = React.memo(({
   extensionsCfg,
 }) => {
   const searchParamContext = React.useContext(SearchParamContext)
+  const [showDownloadSbomPopover, setShowDownloadSbomPopover] = React.useState(false)
   const now = new Date()
 
   return <Grid
@@ -1250,13 +1252,23 @@ const DependenciesTabHeader = React.memo(({
         isLoading={isComponentLoading}
       />
       {
-        extensionsCfg?.sbom_generator?.enabled && <DownloadSbom
-          component={component}
-          ocmRepo={searchParamContext.get('ocmRepo')}
-          isLoading={isComponentLoading}
-        />
+        extensionsCfg?.sbom_generator?.enabled &&
+          <OpenSbomPopoverButton
+            onClick={() => setShowDownloadSbomPopover(true)}
+            isLoading={isComponentLoading}
+          />
       }
     </Grid>
+    {
+      showDownloadSbomPopover &&
+        <SbomDownloadPopover
+          component={component}
+          ocmRepo={searchParamContext.get('ocmRepo')}
+          isComponentLoading={isComponentLoading}
+          onClose={() => setShowDownloadSbomPopover(false)}
+          extensionsCfg={extensionsCfg}
+        />
+    }
   </Grid>
 })
 DependenciesTabHeader.displayName = 'DependenciesTabHeader'

--- a/src/consts.js
+++ b/src/consts.js
@@ -203,6 +203,7 @@ export const COMPLIANCE_TOOLS = {
   OSID: 'osid',
   RESPONSIBLES: 'responsibles',
   SAST: 'sast',
+  SBOM_GENERATOR: 'sbomGenerator'
 }
 
 export const PRIORITIES = {

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -498,8 +498,8 @@ const useFetchQueryMetadata = ({
   }, [featureRegistrationContext])
 
   const fetchCondition = React.useCallback(() => {
-    return deliveryDbFeature?.isAvailable
-  }, [deliveryDbFeature])
+    return deliveryDbFeature?.isAvailable && artefacts?.length > 0
+  }, [deliveryDbFeature, artefacts])
 
   const params = React.useMemo(() => ({
     artefacts,

--- a/src/ocm/model.js
+++ b/src/ocm/model.js
@@ -94,6 +94,7 @@ const datasources = {
   CC_UTILS: 'cc-utils',
   CRYPTO: 'crypto',
   BLACKDUCK: 'blackduck',
+  SBOM_GENERATOR: 'sbom-generator'
 }
 Object.freeze(datasources)
 

--- a/src/util/downloadButtons.js
+++ b/src/util/downloadButtons.js
@@ -71,8 +71,6 @@ DownloadBom.propTypes = {
   isLoading: PropTypes.bool.isRequired,
 }
 
-const sbomCache = {}
-
 export const OpenSbomPopoverButton = ({ onClick, isLoading }) => {
   return (
     <DownloadButton onClick={onClick} isLoading={isLoading}>
@@ -86,23 +84,24 @@ OpenSbomPopoverButton.propTypes = {
   isLoading: PropTypes.bool.isRequired,
 }
 
-export const DownloadSbom = ({ component, ocmRepo, isLoading, buttonText }) => {
+export const DownloadSbom = ({ component, ocmRepo, isLoading, buttonText, onError }) => {
   const handleClick = async () => {
-    const key = `${component.name}:${component.version}`
-    if (!sbomCache[key]) {
-      sbomCache[key] = await components.componentSbom({
+    try {
+      const sbom = await components.componentSbom({
         componentName: component.name,
         componentVersion: component.version,
         ocmRepoUrl: ocmRepo,
       })
+
+      const fname = `${component.name ? component.name : component.target}_${component.version}.sbom.tar`
+
+      downloadObject({
+        obj: sbom,
+        fname: fname,
+      })
+    } catch (error) {
+      if (onError) onError(error)
     }
-
-    const fname = `${component.name ? component.name : component.target}_${component.version}.sbom.tar`
-
-    downloadObject({
-      obj: sbomCache[key],
-      fname: fname,
-    })
   }
 
   return (
@@ -117,4 +116,5 @@ DownloadSbom.propTypes = {
   ocmRepo: PropTypes.string,
   isLoading: PropTypes.bool.isRequired,
   buttonText: PropTypes.string,
+  onError: PropTypes.func,
 }

--- a/src/util/downloadButtons.js
+++ b/src/util/downloadButtons.js
@@ -10,11 +10,33 @@ import { useTheme } from '@emotion/react'
 import { downloadObject } from '../util'
 import { components } from '../api'
 
+export const DownloadButton = ({ onClick, isLoading, children }) => {
+  const theme = useTheme()
+
+  return (
+    <Button
+      startIcon={<CloudDownloadIcon />}
+      onClick={onClick}
+      variant='outlined'
+      style={{
+        color: isLoading ? 'grey' : theme.bomButton.color,
+      }}
+      disabled={isLoading}
+    >
+      {children}
+    </Button>
+  )
+}
+DownloadButton.displayName = 'DownloadButton'
+DownloadButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+  children: PropTypes.node.isRequired,
+}
+
 const bomCache = {}
 
 export const DownloadBom = ({ component, ocmRepo, isLoading }) => {
-  const theme = useTheme()
-
   const handleClick = async () => {
     const key = `${component.name}:${component.version}`
     if (!bomCache[key]) {
@@ -37,20 +59,11 @@ export const DownloadBom = ({ component, ocmRepo, isLoading }) => {
   }
 
   return (
-    <Button
-      startIcon={<CloudDownloadIcon />}
-      onClick={handleClick}
-      variant='outlined'
-      style={{
-        color: isLoading ? 'grey' : theme.bomButton.color,
-      }}
-      disabled={isLoading}
-    >
+    <DownloadButton onClick={handleClick} isLoading={isLoading}>
       download bom
-    </Button>
+    </DownloadButton>
   )
 }
-
 DownloadBom.displayName = 'DownloadBom'
 DownloadBom.propTypes = {
   component: PropTypes.object,
@@ -60,9 +73,20 @@ DownloadBom.propTypes = {
 
 const sbomCache = {}
 
-export const DownloadSbom = ({ component, ocmRepo, isLoading }) => {
-  const theme = useTheme()
+export const OpenSbomPopoverButton = ({ onClick, isLoading }) => {
+  return (
+    <DownloadButton onClick={onClick} isLoading={isLoading}>
+      download sbom
+    </DownloadButton>
+  )
+}
+OpenSbomPopoverButton.displayName = 'OpenSbomPopoverButton'
+OpenSbomPopoverButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+}
 
+export const DownloadSbom = ({ component, ocmRepo, isLoading, buttonText }) => {
   const handleClick = async () => {
     const key = `${component.name}:${component.version}`
     if (!sbomCache[key]) {
@@ -82,22 +106,15 @@ export const DownloadSbom = ({ component, ocmRepo, isLoading }) => {
   }
 
   return (
-    <Button
-      startIcon={<CloudDownloadIcon />}
-      onClick={handleClick}
-      variant='outlined'
-      style={{
-        color: isLoading ? 'grey' : theme.bomButton.color,
-      }}
-      disabled={isLoading}
-    >
-      download sbom
-    </Button>
+    <DownloadButton onClick={handleClick} isLoading={isLoading}>
+      {buttonText ?? 'download sbom'}
+    </DownloadButton>
   )
 }
 DownloadSbom.displayName = 'DownloadSbom'
 DownloadSbom.propTypes = {
-  component: PropTypes.object,
+  component: PropTypes.object.isRequired,
   ocmRepo: PropTypes.string,
   isLoading: PropTypes.bool.isRequired,
+  buttonText: PropTypes.string,
 }

--- a/src/util/missingPermissionsButton.js
+++ b/src/util/missingPermissionsButton.js
@@ -16,6 +16,8 @@ const MissingPermissionsButton = ({
   route,
   method,
   buttonText,
+  variant,
+  fullWidth = true,
 }) => {
   const [rbac, rbacState] = useFetchAuthRbac()
 
@@ -23,7 +25,7 @@ const MissingPermissionsButton = ({
     variant='contained'
     color='secondary'
     disabled
-    fullWidth
+    fullWidth={fullWidth}
   >
     {
       buttonText
@@ -54,12 +56,12 @@ const MissingPermissionsButton = ({
       </>
     }
   >
-    <div style={{ width: '100%' }}> {/* disabled button requires span to be "interactive" */}
+    <div style={fullWidth ? { width: '100%' } : undefined}> {/* disabled button requires span to be "interactive" */}
       <Button
-        variant='contained'
+        variant={variant ?? 'contained'}
         color='secondary'
         disabled
-        fullWidth
+        fullWidth={fullWidth}
       >
         {
           buttonText
@@ -73,6 +75,8 @@ MissingPermissionsButton.propTypes = {
   route: PropTypes.string.isRequired,
   method: PropTypes.string.isRequired,
   buttonText: PropTypes.string.isRequired,
+  variant: PropTypes.string,
+  fullWidth: PropTypes.bool,
 }
 
 

--- a/src/util/sbomDownloadPopover.js
+++ b/src/util/sbomDownloadPopover.js
@@ -1,0 +1,355 @@
+import React from 'react'
+
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  Tooltip,
+} from '@mui/material'
+import BlockIcon from '@mui/icons-material/Block'
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
+import WarningAmberIcon from '@mui/icons-material/WarningAmber'
+
+import PropTypes from 'prop-types'
+import { useSnackbar } from 'notistack'
+
+import { DownloadSbom } from './downloadButtons'
+import { useFetchQueryMetadata, useFetchBom } from '../fetch'
+import { artefactMetadataTypes } from '../ocm/model'
+import { errorSnackbarProps, fetchBomPopulate, ARTEFACT_KIND } from '../consts'
+import ScrollableList from './scrollableList'
+import { serviceExtensions } from '../api'
+
+const SBOM_GENERATOR_SERVICE = 'sbomGenerator'
+const SBOM_GENERATOR_DATASOURCE = 'sbom-generator'
+const POLL_INTERVAL_MS = 10000
+
+const SUPPORTED_ACCESS_TYPES_BY_MODE = {
+  syft: ['ociRegistry'],
+  bdba: ['ociRegistry', 'localBlob/v1', 's3'],
+}
+
+const SUPPORTED_ARTEFACT_TYPES_BY_MODE = {
+  syft: ['ociImage', 'directoryTree'],
+  // bdba: no artefact type restriction
+}
+
+const isResourceSupported = (resource, generationMode) => {
+  const accessType = resource?.access?.type
+  const artefactType = resource?.type
+
+  const supportedAccessTypes = SUPPORTED_ACCESS_TYPES_BY_MODE[generationMode]
+  if (supportedAccessTypes && !supportedAccessTypes.includes(accessType))
+    return false
+
+  const supportedArtefactTypes =
+    SUPPORTED_ARTEFACT_TYPES_BY_MODE[generationMode]
+  if (
+    supportedArtefactTypes &&
+    artefactType &&
+    !supportedArtefactTypes.includes(artefactType)
+  )
+    return false
+
+  return true
+}
+
+const SbomDownloadPopover = ({
+  component,
+  ocmRepo,
+  isComponentLoading,
+  onClose,
+  extensionsCfg,
+}) => {
+  const { enqueueSnackbar } = useSnackbar()
+  const [isTriggering, setIsTriggering] = React.useState(false)
+  const [isPolling, setIsPolling] = React.useState(false)
+  const pollIntervalRef = React.useRef(null)
+
+  const [bom, bomState] = useFetchBom({
+    componentName: component.name,
+    componentVersion: component.version,
+    ocmRepo: ocmRepo,
+    populate: fetchBomPopulate.ALL,
+  })
+
+  const artefacts = React.useMemo(() => {
+    if (!bom?.componentDependencies) return null
+    return bom.componentDependencies.flatMap((c) =>
+      c.resources.map((resource) => ({
+        component_name: c.name,
+        component_version: c.version,
+        artefact_kind: ARTEFACT_KIND.RESOURCE,
+        artefact: {
+          artefact_name: resource.name,
+          artefact_version: resource.version,
+          artefact_type: resource.type,
+          artefact_extra_id: resource.extraIdentity,
+        },
+      })),
+    )
+  }, [bom])
+
+  const types = React.useMemo(() => {
+    return [artefactMetadataTypes.ARTEFACT_SCAN_INFO]
+  }, [])
+
+  const [scanInfos, scanInfosState, refreshScanInfos] = useFetchQueryMetadata({
+    artefacts: artefacts ?? [],
+    types: types,
+  })
+
+  const generationMode =
+    extensionsCfg?.sbom_generator?.generation_mode ?? 'syft'
+
+  const sbomReadiness = React.useMemo(() => {
+    if (!bom?.componentDependencies || !scanInfos) return null
+
+    const componentReadiness = bom.componentDependencies.flatMap((c) =>
+      c.resources.map((resource) => {
+        const isSupported = isResourceSupported(resource, generationMode)
+
+        const hasScan =
+          isSupported &&
+          scanInfos.some(
+            (entry) =>
+              entry.meta.type === artefactMetadataTypes.ARTEFACT_SCAN_INFO &&
+              entry.meta.datasource === SBOM_GENERATOR_DATASOURCE &&
+              entry.artefact?.component_name === c.name &&
+              entry.artefact?.component_version === c.version &&
+              entry.artefact?.artefact?.artefact_name === resource.name,
+          )
+
+        return {
+          name: resource.name,
+          version: resource.version,
+          accessType: resource?.access?.type,
+          artefactType: resource?.type,
+          component: `${c.name}:${c.version}`,
+          ready: hasScan,
+          supported: isSupported,
+        }
+      }),
+    )
+
+    return componentReadiness
+  }, [bom, scanInfos, generationMode])
+
+  const readyComponents = sbomReadiness?.filter((c) => c.ready) ?? []
+  const notReadyComponents =
+    sbomReadiness?.filter((c) => !c.ready && c.supported) ?? []
+  const unsupportedComponents =
+    sbomReadiness?.filter((c) => !c.supported) ?? []
+
+  React.useEffect(() => {
+    if (
+      isPolling &&
+      notReadyComponents.length === 0 &&
+      sbomReadiness !== null
+    ) {
+      clearInterval(pollIntervalRef.current)
+      pollIntervalRef.current = null
+      setIsPolling(false)
+    }
+  }, [isPolling, notReadyComponents.length, sbomReadiness])
+
+  React.useEffect(() => {
+    return () => {
+      if (pollIntervalRef.current) {
+        clearInterval(pollIntervalRef.current)
+      }
+    }
+  }, [])
+
+  const isLoading =
+    isComponentLoading ||
+    bomState.isLoading ||
+    (!isPolling && scanInfosState.isLoading)
+  const isError = bomState.error || scanInfosState.error
+  const isDisabled = isLoading || isTriggering || isPolling
+  const isClosable = !isLoading && !isTriggering
+
+  const toListItem = (r) => ({
+    primary: `${r.name}${r.version ? `:${r.version}` : ''}`,
+    secondary: `${r.accessType ? `${r.accessType}` : ''}${r.artefactType ? ` · ${r.artefactType}` : ''}`,
+    component: r.component,
+  })
+
+  const triggerSbomGeneration = async () => {
+    if (!artefacts || notReadyComponents.length === 0) return
+
+    const notReadyKeys = new Set(
+      notReadyComponents.map((r) => `${r.component}:${r.name}`),
+    )
+    const backlogArtefacts = artefacts.filter((a) =>
+      notReadyKeys.has(
+        `${a.component_name}:${a.component_version}:${a.artefact.artefact_name}`,
+      ),
+    )
+
+    setIsTriggering(true)
+    try {
+      await serviceExtensions.backlogItems.create({
+        service: SBOM_GENERATOR_SERVICE,
+        priority: 'Critical',
+        artefacts: backlogArtefacts,
+      })
+      enqueueSnackbar(
+        `Successfully scheduled SBOM generation for ${backlogArtefacts.length} component(s)`,
+        {
+          variant: 'success',
+          anchorOrigin: { vertical: 'bottom', horizontal: 'right' },
+          autoHideDuration: 6000,
+        },
+      )
+
+      setIsPolling(true)
+      pollIntervalRef.current = setInterval(() => {
+        refreshScanInfos()
+      }, POLL_INTERVAL_MS)
+    } catch (error) {
+      enqueueSnackbar('Could not schedule SBOM generation', {
+        ...errorSnackbarProps,
+        details: error.toString(),
+        onRetry: triggerSbomGeneration,
+      })
+    } finally {
+      setIsTriggering(false)
+    }
+  }
+
+  return (
+    <Dialog
+      open={true}
+      onClose={isClosable ? onClose : undefined}
+      maxWidth="md"
+      fullWidth
+    >
+      <DialogTitle
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        Download SBOM
+        <Box display="flex" gap={1}>
+          {generationMode && (
+            <Tooltip title="Generation mode">
+              <Chip label={generationMode} size="small" variant="outlined" />
+            </Tooltip>
+          )}
+          {extensionsCfg?.sbom_generator?.output_format && (
+            <Tooltip title="Output format">
+              <Chip
+                label={extensionsCfg.sbom_generator.output_format}
+                size="small"
+                variant="outlined"
+              />
+            </Tooltip>
+          )}
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        {isLoading ? (
+          <Box display="flex" justifyContent="center" py={4}>
+            <CircularProgress size={32} />
+          </Box>
+        ) : isError ? (
+          <Alert severity="error">Failed to check SBOM readiness.</Alert>
+        ) : (
+          <Stack spacing={2} mt={0.5}>
+            {isPolling && (
+              <Alert severity="info" icon={<CircularProgress size={16} />}>
+                Waiting for SBOM generation to complete...
+              </Alert>
+            )}
+            {generationMode && unsupportedComponents.length > 0 && (
+              <Alert severity="warning">
+                {`Generation mode "${generationMode}" does not support all artefact access types. Unsupported components are listed below and will be skipped.`}
+              </Alert>
+            )}
+            <ScrollableList
+              title={`Ready (${readyComponents.length})`}
+              titleIcon={
+                <CheckCircleOutlineIcon color="success" fontSize="small" />
+              }
+              titleColor="success.main"
+              items={readyComponents.map(toListItem)}
+              emptyText="No SBOMs are ready yet."
+              maxHeight="220px"
+              groupBy="component"
+            />
+            <ScrollableList
+              title={`Not ready (${notReadyComponents.length})`}
+              titleIcon={<WarningAmberIcon color="warning" fontSize="small" />}
+              titleColor="warning.main"
+              items={notReadyComponents.map(toListItem)}
+              emptyText="All SBOMs are ready."
+              maxHeight="220px"
+              groupBy="component"
+            />
+            {unsupportedComponents.length > 0 && (
+              <ScrollableList
+                title={`Unsupported (${unsupportedComponents.length})`}
+                titleIcon={<BlockIcon color="error" fontSize="small" />}
+                titleColor="error.main"
+                items={unsupportedComponents.map(toListItem)}
+                emptyText=""
+                maxHeight="220px"
+                groupBy="component"
+              />
+            )}
+          </Stack>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="error" disabled={!isClosable}>
+          Abort
+        </Button>
+        {notReadyComponents && notReadyComponents.length > 0 && (
+          <Button
+            color="secondary"
+            onClick={triggerSbomGeneration}
+            disabled={isDisabled}
+            startIcon={
+              isTriggering ? <CircularProgress size={16} /> : undefined
+            }
+          >
+            Trigger SBOM generation
+          </Button>
+        )}
+        <DownloadSbom
+          component={component}
+          ocmRepo={ocmRepo}
+          isLoading={isLoading || isDisabled || readyComponents.length === 0}
+          buttonText={
+            isLoading
+              ? 'loading...'
+              : notReadyComponents.length > 0 ||
+                  unsupportedComponents.length > 0
+                ? 'download anyway'
+                : 'download sbom'
+          }
+        />
+      </DialogActions>
+    </Dialog>
+  )
+}
+SbomDownloadPopover.displayName = 'SbomDownloadPopover'
+SbomDownloadPopover.propTypes = {
+  component: PropTypes.object.isRequired,
+  ocmRepo: PropTypes.string,
+  isComponentLoading: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  extensionsCfg: PropTypes.object,
+}
+
+export default SbomDownloadPopover

--- a/src/util/sbomDownloadPopover.js
+++ b/src/util/sbomDownloadPopover.js
@@ -21,14 +21,16 @@ import PropTypes from 'prop-types'
 import { useSnackbar } from 'notistack'
 
 import { DownloadSbom } from './downloadButtons'
-import { useFetchQueryMetadata, useFetchBom } from '../fetch'
+import MissingPermissionsButton from './missingPermissionsButton'
+import { useFetchQueryMetadata, useFetchBom, useFetchAuthUser } from '../fetch'
 import { artefactMetadataTypes } from '../ocm/model'
 import { errorSnackbarProps, fetchBomPopulate, ARTEFACT_KIND } from '../consts'
 import ScrollableList from './scrollableList'
-import { serviceExtensions } from '../api'
+import { routes, serviceExtensions } from '../api'
+import { COMPLIANCE_TOOLS, PRIORITIES } from '../consts'
+import { datasources } from '../ocm/model'
+import { hasUserAccess, normaliseExtraIdentity } from '../util'
 
-const SBOM_GENERATOR_SERVICE = 'sbomGenerator'
-const SBOM_GENERATOR_DATASOURCE = 'sbom-generator'
 const POLL_INTERVAL_MS = 10000
 
 const SUPPORTED_ACCESS_TYPES_BY_MODE = {
@@ -46,11 +48,12 @@ const isResourceSupported = (resource, generationMode) => {
   const artefactType = resource?.type
 
   const supportedAccessTypes = SUPPORTED_ACCESS_TYPES_BY_MODE[generationMode]
-  if (supportedAccessTypes && !supportedAccessTypes.includes(accessType))
+  if (supportedAccessTypes && 
+      accessType &&
+      !supportedAccessTypes.includes(accessType))
     return false
 
-  const supportedArtefactTypes =
-    SUPPORTED_ARTEFACT_TYPES_BY_MODE[generationMode]
+  const supportedArtefactTypes = SUPPORTED_ARTEFACT_TYPES_BY_MODE[generationMode]
   if (
     supportedArtefactTypes &&
     artefactType &&
@@ -102,12 +105,20 @@ const SbomDownloadPopover = ({
   }, [])
 
   const [scanInfos, scanInfosState, refreshScanInfos] = useFetchQueryMetadata({
-    artefacts: artefacts ?? [],
+    artefacts: artefacts,
     types: types,
   })
 
-  const generationMode =
-    extensionsCfg?.sbom_generator?.generation_mode ?? 'syft'
+  const [user] = useFetchAuthUser()
+  const route = new URL(routes.serviceExtensions.backlogItems()).pathname
+  const method = 'POST'
+  const isAuthorised = hasUserAccess({
+    permissions: user?.permissions,
+    route: route,
+    method: method,
+  })
+
+  const generationMode = extensionsCfg?.sbom_generator?.generation_mode ?? 'syft'
 
   const sbomReadiness = React.useMemo(() => {
     if (!bom?.componentDependencies || !scanInfos) return null
@@ -121,10 +132,13 @@ const SbomDownloadPopover = ({
           scanInfos.some(
             (entry) =>
               entry.meta.type === artefactMetadataTypes.ARTEFACT_SCAN_INFO &&
-              entry.meta.datasource === SBOM_GENERATOR_DATASOURCE &&
-              entry.artefact?.component_name === c.name &&
-              entry.artefact?.component_version === c.version &&
-              entry.artefact?.artefact?.artefact_name === resource.name,
+              entry.meta.datasource === datasources.SBOM_GENERATOR &&
+              entry.artefact.component_name === c.name &&
+              entry.artefact.component_version === c.version &&
+              entry.artefact.artefact.artefact_name === resource.name &&
+              entry.artefact.artefact.artefact_version === resource.version &&
+              entry.artefact.artefact.artefact_type === resource.type &&
+              normaliseExtraIdentity(entry.artefact.artefact.artefact_extra_id) === normaliseExtraIdentity(resource.extraIdentity),
           )
 
         return {
@@ -132,6 +146,7 @@ const SbomDownloadPopover = ({
           version: resource.version,
           accessType: resource?.access?.type,
           artefactType: resource?.type,
+          extraIdentity: resource.extraIdentity,
           component: `${c.name}:${c.version}`,
           ready: hasScan,
           supported: isSupported,
@@ -143,10 +158,8 @@ const SbomDownloadPopover = ({
   }, [bom, scanInfos, generationMode])
 
   const readyComponents = sbomReadiness?.filter((c) => c.ready) ?? []
-  const notReadyComponents =
-    sbomReadiness?.filter((c) => !c.ready && c.supported) ?? []
-  const unsupportedComponents =
-    sbomReadiness?.filter((c) => !c.supported) ?? []
+  const notReadyComponents = sbomReadiness?.filter((c) => !c.ready && c.supported) ?? []
+  const unsupportedComponents = sbomReadiness?.filter((c) => !c.supported) ?? []
 
   React.useEffect(() => {
     if (
@@ -177,7 +190,7 @@ const SbomDownloadPopover = ({
   const isClosable = !isLoading && !isTriggering
 
   const toListItem = (r) => ({
-    primary: `${r.name}${r.version ? `:${r.version}` : ''}`,
+    primary: `${r.name}:${r.version}`,
     secondary: `${r.accessType ? `${r.accessType}` : ''}${r.artefactType ? ` · ${r.artefactType}` : ''}`,
     component: r.component,
   })
@@ -186,19 +199,19 @@ const SbomDownloadPopover = ({
     if (!artefacts || notReadyComponents.length === 0) return
 
     const notReadyKeys = new Set(
-      notReadyComponents.map((r) => `${r.component}:${r.name}`),
+      notReadyComponents.map((r) => `${r.component}:${r.name}:${r.version}:${r.artefactType}:${normaliseExtraIdentity(r.extraIdentity)}`),
     )
     const backlogArtefacts = artefacts.filter((a) =>
       notReadyKeys.has(
-        `${a.component_name}:${a.component_version}:${a.artefact.artefact_name}`,
+        `${a.component_name}:${a.component_version}:${a.artefact.artefact_name}:${a.artefact.artefact_version}:${a.artefact.artefact_type}:${normaliseExtraIdentity(a.artefact.artefact_extra_id)}`,
       ),
     )
 
     setIsTriggering(true)
     try {
       await serviceExtensions.backlogItems.create({
-        service: SBOM_GENERATOR_SERVICE,
-        priority: 'Critical',
+        service: COMPLIANCE_TOOLS.SBOM_GENERATOR,
+        priority: PRIORITIES.CRITICAL.name,
         artefacts: backlogArtefacts,
       })
       enqueueSnackbar(
@@ -229,7 +242,7 @@ const SbomDownloadPopover = ({
     <Dialog
       open={true}
       onClose={isClosable ? onClose : undefined}
-      maxWidth="md"
+      maxWidth='md'
       fullWidth
     >
       <DialogTitle
@@ -240,18 +253,18 @@ const SbomDownloadPopover = ({
         }}
       >
         Download SBOM
-        <Box display="flex" gap={1}>
+        <Box display='flex' gap={1}>
           {generationMode && (
-            <Tooltip title="Generation mode">
-              <Chip label={generationMode} size="small" variant="outlined" />
+            <Tooltip title='Generation mode'>
+              <Chip label={generationMode} size='small' variant='outlined' />
             </Tooltip>
           )}
           {extensionsCfg?.sbom_generator?.output_format && (
-            <Tooltip title="Output format">
+            <Tooltip title='Output format'>
               <Chip
                 label={extensionsCfg.sbom_generator.output_format}
-                size="small"
-                variant="outlined"
+                size='small'
+                variant='outlined'
               />
             </Tooltip>
           )}
@@ -259,72 +272,82 @@ const SbomDownloadPopover = ({
       </DialogTitle>
       <DialogContent>
         {isLoading ? (
-          <Box display="flex" justifyContent="center" py={4}>
+          <Box display='flex' justifyContent='center' py={4}>
             <CircularProgress size={32} />
           </Box>
         ) : isError ? (
-          <Alert severity="error">Failed to check SBOM readiness.</Alert>
+          <Alert severity='error'>Failed to check SBOM readiness.</Alert>
         ) : (
           <Stack spacing={2} mt={0.5}>
             {isPolling && (
-              <Alert severity="info" icon={<CircularProgress size={16} />}>
+              <Alert severity='info' icon={<CircularProgress size={16} />}>
                 Waiting for SBOM generation to complete...
               </Alert>
             )}
             {generationMode && unsupportedComponents.length > 0 && (
-              <Alert severity="warning">
-                {`Generation mode "${generationMode}" does not support all artefact access types. Unsupported components are listed below and will be skipped.`}
+              <Alert severity='warning'>
+                {`Generation mode '${generationMode}' does not support all artefact access types. Unsupported components are listed below and will be skipped.`}
               </Alert>
             )}
             <ScrollableList
               title={`Ready (${readyComponents.length})`}
               titleIcon={
-                <CheckCircleOutlineIcon color="success" fontSize="small" />
+                <CheckCircleOutlineIcon color='success' fontSize='small' />
               }
-              titleColor="success.main"
+              titleColor='success.main'
               items={readyComponents.map(toListItem)}
-              emptyText="No SBOMs are ready yet."
-              maxHeight="220px"
-              groupBy="component"
+              emptyText='No SBOMs are ready yet.'
+              maxHeight='220px'
+              groupBy='component'
             />
             <ScrollableList
               title={`Not ready (${notReadyComponents.length})`}
-              titleIcon={<WarningAmberIcon color="warning" fontSize="small" />}
-              titleColor="warning.main"
+              titleIcon={<WarningAmberIcon color='warning' fontSize='small' />}
+              titleColor='warning.main'
               items={notReadyComponents.map(toListItem)}
-              emptyText="All SBOMs are ready."
-              maxHeight="220px"
-              groupBy="component"
+              emptyText='All SBOMs are ready.'
+              maxHeight='220px'
+              groupBy='component'
             />
             {unsupportedComponents.length > 0 && (
               <ScrollableList
                 title={`Unsupported (${unsupportedComponents.length})`}
-                titleIcon={<BlockIcon color="error" fontSize="small" />}
-                titleColor="error.main"
+                titleIcon={<BlockIcon color='error' fontSize='small' />}
+                titleColor='error.main'
                 items={unsupportedComponents.map(toListItem)}
-                emptyText=""
-                maxHeight="220px"
-                groupBy="component"
+                emptyText=''
+                maxHeight='220px'
+                groupBy='component'
               />
             )}
           </Stack>
         )}
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} color="error" disabled={!isClosable}>
-          Abort
+        <Button onClick={onClose} color='error' disabled={!isClosable}>
+          Cancel
         </Button>
         {notReadyComponents && notReadyComponents.length > 0 && (
-          <Button
-            color="secondary"
-            onClick={triggerSbomGeneration}
-            disabled={isDisabled}
-            startIcon={
-              isTriggering ? <CircularProgress size={16} /> : undefined
-            }
-          >
-            Trigger SBOM generation
-          </Button>
+          isAuthorised ? (
+            <Button
+              color='secondary'
+              onClick={triggerSbomGeneration}
+              disabled={isDisabled}
+              startIcon={
+                isTriggering && <CircularProgress size={16} />
+              }
+            >
+              Trigger SBOM generation
+            </Button>
+          ) : (
+            <MissingPermissionsButton
+              route={route}
+              method={method}
+              buttonText='Trigger SBOM generation'
+              variant='text'
+              fullWidth={false}
+            />
+          )
         )}
         <DownloadSbom
           component={component}
@@ -333,8 +356,7 @@ const SbomDownloadPopover = ({
           buttonText={
             isLoading
               ? 'loading...'
-              : notReadyComponents.length > 0 ||
-                  unsupportedComponents.length > 0
+              : notReadyComponents.length > 0
                 ? 'download anyway'
                 : 'download sbom'
           }

--- a/src/util/sbomDownloadPopover.js
+++ b/src/util/sbomDownloadPopover.js
@@ -360,6 +360,10 @@ const SbomDownloadPopover = ({
                 ? 'download anyway'
                 : 'download sbom'
           }
+          onError={(error) => enqueueSnackbar('Could not download SBOM', {
+            ...errorSnackbarProps,
+            details: error.toString(),
+          })}
         />
       </DialogActions>
     </Dialog>

--- a/src/util/scrollableList.js
+++ b/src/util/scrollableList.js
@@ -36,16 +36,16 @@ const GroupedSection = ({ groupKey, items, renderItem }) => {
           primary={groupKey}
           primaryTypographyProps={{ variant: 'body2', fontWeight: 'bold' }}
         />
-        <Typography variant="caption" color="text.secondary" sx={{ mr: 0.5 }}>
+        <Typography variant='caption' color='text.secondary' sx={{ mr: 0.5 }}>
           {items.length}
         </Typography>
         {open ? (
-          <ExpandLessIcon fontSize="small" />
+          <ExpandLessIcon fontSize='small' />
         ) : (
-          <ExpandMoreIcon fontSize="small" />
+          <ExpandMoreIcon fontSize='small' />
         )}
       </ListItemButton>
-      <Collapse in={open} timeout="auto" unmountOnExit>
+      <Collapse in={open} timeout='auto' unmountOnExit>
         <List dense disablePadding>
           {items.map((item, idx) => (
             <ListItem key={idx} disablePadding sx={{ px: 2.5, py: 0.25 }}>
@@ -151,15 +151,15 @@ const ScrollableList = ({
   }, [items, groupBy])
 
   const titleRow = (
-    <Box display="flex" alignItems="center" gap={0.5}>
+    <Box display='flex' alignItems='center' gap={0.5}>
       {titleIcon}
-      <Typography variant="subtitle2" color={titleColor} sx={{ flexGrow: 1 }}>
+      <Typography variant='subtitle2' color={titleColor} sx={{ flexGrow: 1 }}>
         {title}
       </Typography>
       {items.length > 0 && (
-        <Tooltip title="Expand">
-          <IconButton size="small" onClick={() => setExpanded(true)}>
-            <OpenInFullIcon fontSize="small" />
+        <Tooltip title='Expand'>
+          <IconButton size='small' onClick={() => setExpanded(true)}>
+            <OpenInFullIcon fontSize='small' />
           </IconButton>
         </Tooltip>
       )}
@@ -180,7 +180,7 @@ const ScrollableList = ({
         }}
       >
         {items.length === 0 ? (
-          <Typography variant="body2" color="text.secondary" sx={{ p: 1.5 }}>
+          <Typography variant='body2' color='text.secondary' sx={{ p: 1.5 }}>
             {emptyText ?? 'No items.'}
           </Typography>
         ) : (
@@ -191,7 +191,7 @@ const ScrollableList = ({
       <Dialog
         open={expanded}
         onClose={() => setExpanded(false)}
-        maxWidth="md"
+        maxWidth='md'
         fullWidth
       >
         <DialogTitle
@@ -201,14 +201,14 @@ const ScrollableList = ({
             justifyContent: 'space-between',
           }}
         >
-          <Box display="flex" alignItems="center" gap={0.5}>
+          <Box display='flex' alignItems='center' gap={0.5}>
             {titleIcon}
-            <Typography variant="subtitle1" color={titleColor}>
+            <Typography variant='subtitle1' color={titleColor}>
               {title}
             </Typography>
           </Box>
-          <IconButton size="small" onClick={() => setExpanded(false)}>
-            <CloseIcon fontSize="small" />
+          <IconButton size='small' onClick={() => setExpanded(false)}>
+            <CloseIcon fontSize='small' />
           </IconButton>
         </DialogTitle>
         <DialogContent dividers sx={{ p: 0 }}>

--- a/src/util/scrollableList.js
+++ b/src/util/scrollableList.js
@@ -1,0 +1,233 @@
+import React from 'react'
+
+import {
+  Box,
+  Collapse,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
+import ExpandLessIcon from '@mui/icons-material/ExpandLess'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import OpenInFullIcon from '@mui/icons-material/OpenInFull'
+
+import PropTypes from 'prop-types'
+
+const GroupedSection = ({ groupKey, items, renderItem }) => {
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    <>
+      <ListItemButton
+        onClick={() => setOpen((prev) => !prev)}
+        sx={{ px: 1.5, py: 0.5 }}
+        dense
+      >
+        <ListItemText
+          primary={groupKey}
+          primaryTypographyProps={{ variant: 'body2', fontWeight: 'bold' }}
+        />
+        <Typography variant="caption" color="text.secondary" sx={{ mr: 0.5 }}>
+          {items.length}
+        </Typography>
+        {open ? (
+          <ExpandLessIcon fontSize="small" />
+        ) : (
+          <ExpandMoreIcon fontSize="small" />
+        )}
+      </ListItemButton>
+      <Collapse in={open} timeout="auto" unmountOnExit>
+        <List dense disablePadding>
+          {items.map((item, idx) => (
+            <ListItem key={idx} disablePadding sx={{ px: 2.5, py: 0.25 }}>
+              {renderItem ? (
+                renderItem(item)
+              ) : (
+                <>
+                  {item.icon && (
+                    <ListItemIcon sx={{ minWidth: 28 }}>
+                      {item.icon}
+                    </ListItemIcon>
+                  )}
+                  <ListItemText
+                    primary={item.primary}
+                    secondary={item.secondary}
+                    primaryTypographyProps={{ variant: 'body2' }}
+                    secondaryTypographyProps={{ variant: 'caption' }}
+                  />
+                </>
+              )}
+            </ListItem>
+          ))}
+        </List>
+      </Collapse>
+    </>
+  )
+}
+GroupedSection.propTypes = {
+  groupKey: PropTypes.string.isRequired,
+  items: PropTypes.array.isRequired,
+  renderItem: PropTypes.func,
+}
+
+const ListContent = ({ items, groups, renderItem }) => {
+  if (items.length === 0) return null
+
+  if (groups) {
+    return (
+      <List dense disablePadding>
+        {[...groups.entries()].map(([groupKey, groupItems]) => (
+          <GroupedSection
+            key={groupKey}
+            groupKey={groupKey}
+            items={groupItems}
+            renderItem={renderItem}
+          />
+        ))}
+      </List>
+    )
+  }
+
+  return (
+    <List dense disablePadding>
+      {items.map((item, idx) => (
+        <ListItem key={idx} disablePadding sx={{ px: 1.5, py: 0.25 }}>
+          {renderItem ? (
+            renderItem(item)
+          ) : (
+            <>
+              {item.icon && (
+                <ListItemIcon sx={{ minWidth: 28 }}>{item.icon}</ListItemIcon>
+              )}
+              <ListItemText
+                primary={item.primary}
+                secondary={item.secondary}
+                primaryTypographyProps={{ variant: 'body2' }}
+                secondaryTypographyProps={{ variant: 'caption' }}
+              />
+            </>
+          )}
+        </ListItem>
+      ))}
+    </List>
+  )
+}
+ListContent.propTypes = {
+  items: PropTypes.array.isRequired,
+  groups: PropTypes.instanceOf(Map),
+  renderItem: PropTypes.func,
+}
+
+const ScrollableList = ({
+  title,
+  titleIcon,
+  titleColor,
+  items,
+  renderItem,
+  maxHeight,
+  emptyText,
+  groupBy,
+}) => {
+  const [expanded, setExpanded] = React.useState(false)
+
+  const groups = React.useMemo(() => {
+    if (!groupBy) return null
+    const map = new Map()
+    for (const item of items) {
+      const key = item[groupBy] ?? ''
+      if (!map.has(key)) map.set(key, [])
+      map.get(key).push(item)
+    }
+    return map
+  }, [items, groupBy])
+
+  const titleRow = (
+    <Box display="flex" alignItems="center" gap={0.5}>
+      {titleIcon}
+      <Typography variant="subtitle2" color={titleColor} sx={{ flexGrow: 1 }}>
+        {title}
+      </Typography>
+      {items.length > 0 && (
+        <Tooltip title="Expand">
+          <IconButton size="small" onClick={() => setExpanded(true)}>
+            <OpenInFullIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      )}
+    </Box>
+  )
+
+  return (
+    <Box>
+      {titleRow}
+      <Box
+        sx={{
+          maxHeight: maxHeight ?? '200px',
+          overflowY: 'auto',
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: 1,
+          mt: 0.5,
+        }}
+      >
+        {items.length === 0 ? (
+          <Typography variant="body2" color="text.secondary" sx={{ p: 1.5 }}>
+            {emptyText ?? 'No items.'}
+          </Typography>
+        ) : (
+          <ListContent items={items} groups={groups} renderItem={renderItem} />
+        )}
+      </Box>
+
+      <Dialog
+        open={expanded}
+        onClose={() => setExpanded(false)}
+        maxWidth="md"
+        fullWidth
+      >
+        <DialogTitle
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <Box display="flex" alignItems="center" gap={0.5}>
+            {titleIcon}
+            <Typography variant="subtitle1" color={titleColor}>
+              {title}
+            </Typography>
+          </Box>
+          <IconButton size="small" onClick={() => setExpanded(false)}>
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent dividers sx={{ p: 0 }}>
+          <ListContent items={items} groups={groups} renderItem={renderItem} />
+        </DialogContent>
+      </Dialog>
+    </Box>
+  )
+}
+ScrollableList.displayName = 'ScrollableList'
+ScrollableList.propTypes = {
+  title: PropTypes.string.isRequired,
+  titleIcon: PropTypes.node,
+  titleColor: PropTypes.string,
+  items: PropTypes.array.isRequired,
+  renderItem: PropTypes.func,
+  maxHeight: PropTypes.string,
+  emptyText: PropTypes.string,
+  groupBy: PropTypes.string,
+}
+
+export default ScrollableList


### PR DESCRIPTION
**What this PR does / why we need it**: This PR replaces the one-click "Download SBOM" button with an SBOM Download dialog that shows per-resource SBOM readiness before downloading. Previously, clicking "download sbom" would immediately fetch and download whatever SBOM data was available with no visibility into completeness. It allows users to trigger SBOM generation for resources that aren't ready yet, with polling to track progress.

**Which issue(s) this PR fixes**:
Fixes https://github.com/open-component-model/open-delivery-gear/issues/33

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```feature user
Add SBoM download popover
```
