### PR TITLE
refactor(ocm): Streamline OCM component name and repository branding

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,6 +2,5 @@
 REACT_APP_DASHBOARD_TITLE='Open Delivery Gear'
 REACT_APP_DELIVERY_SERVICE_API_URL=http://localhost:5000
 REACT_APP_BUILD_VERSION=dev-build
-REACT_APP_ISSUE_BODY_MARKDOWN_PARSING=true
 REACT_APP_FEATURE_JOKES_API=false
 REACT_APP_DASHBOARD_CREATE_ISSUE_URL=https://github.com/open-component-model/odg-ui/issues/new/choose

--- a/.env.development
+++ b/.env.development
@@ -4,4 +4,4 @@ REACT_APP_DELIVERY_SERVICE_API_URL=http://localhost:5000
 REACT_APP_BUILD_VERSION=dev-build
 REACT_APP_ISSUE_BODY_MARKDOWN_PARSING=true
 REACT_APP_FEATURE_JOKES_API=false
-REACT_APP_DASHBOARD_CREATE_ISSUE_URL=https://github.com/open-component-model/delivery-dashboard/issues/new/choose
+REACT_APP_DASHBOARD_CREATE_ISSUE_URL=https://github.com/open-component-model/odg-ui/issues/new/choose

--- a/.env.production
+++ b/.env.production
@@ -2,6 +2,5 @@ REACT_APP_DASHBOARD_TITLE='Open Delivery Gear'
 REACT_APP_BUILD_VERSION=$build_version
 # REACT_APP_DELIVERY_SERVICE_API_URL=https://your.delivery-service.url
 # hint: injected during deployment
-REACT_APP_ISSUE_BODY_MARKDOWN_PARSING=true
 REACT_APP_FEATURE_JOKES_API=false
 REACT_APP_DASHBOARD_CREATE_ISSUE_URL=https://github.com/open-component-model/odg-ui/issues/new/choose

--- a/.env.production
+++ b/.env.production
@@ -4,4 +4,4 @@ REACT_APP_BUILD_VERSION=$build_version
 # hint: injected during deployment
 REACT_APP_ISSUE_BODY_MARKDOWN_PARSING=true
 REACT_APP_FEATURE_JOKES_API=false
-REACT_APP_DASHBOARD_CREATE_ISSUE_URL=https://github.com/open-component-model/delivery-dashboard/issues/new/choose
+REACT_APP_DASHBOARD_CREATE_ISSUE_URL=https://github.com/open-component-model/odg-ui/issues/new/choose

--- a/.ocm/base-component.yaml
+++ b/.ocm/base-component.yaml
@@ -1,4 +1,4 @@
-name: ocm.software/ocm-gear/delivery-dashboard
+name: ocm.software/open-delivery-gear/ui
 resources:
   - name: busybox
     version: 1.37.0

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-# delivery-dashboard maintainers
+# odg-ui maintainers
 *   @open-component-model/odg-maintainers

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Delivery Dashboard
+# Open Delivery Gear UI
 
-[![REUSE status](https://api.reuse.software/badge/github.com/open-component-model/delivery-dashboard)](https://api.reuse.software/info/github.com/open-component-model/delivery-dashboard)
+[![REUSE status](https://api.reuse.software/badge/github.com/open-component-model/odg-ui)](https://api.reuse.software/info/github.com/open-component-model/odg-ui)
 
-![tests](https://github.com/open-component-model/delivery-dashboard/actions/workflows/non-release.yaml/badge.svg)
-![release](https://github.com/open-component-model/delivery-dashboard/actions/workflows/release.yaml/badge.svg)
+![tests](https://github.com/open-component-model/odg-ui/actions/workflows/non-release.yaml/badge.svg)
+![release](https://github.com/open-component-model/odg-ui/actions/workflows/release.yaml/badge.svg)
 
-This repository os used for developing the `Delivery Dashboard`, which is part of the OCM
-(Delivery) Gear. It is run against the `Delivery Service` as backing API and displays delivery
+This repository is used for developing the `Delivery Dashboard`, which is part of the Open
+Delivery Gear. It is run against the `Delivery Service` as backing API and displays delivery
 metadata for OCM-based deliveries.
 
 It is written in `javascript` and uses `react` as well as the react component
@@ -32,7 +32,7 @@ Please note that linter plugins are expected to be installed in global npm conte
 Either install them via `npm install -g` or adjust `.ci/lint` accordingly.
 
 ```
-> cat delivery-dashboard/.git/hooks/pre-push
+> cat odg-ui/.git/hooks/pre-push
 
 #!/usr/bin/env sh
 set -e

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,10 +1,10 @@
 version = 1
-SPDX-PackageName = "OCM Delivery Dashboard"
-SPDX-PackageSupplier = "Christian Cwienk <christian.cwienk@sap.com>"
-SPDX-PackageDownloadLocation = "https://github.com/open-component-model/delivery-dashboard"
+SPDX-PackageName = "odg-ui"
+SPDX-PackageSupplier = "ospo@sap.com"
+SPDX-PackageDownloadLocation = "https://github.com/open-component-model/odg-ui"
 
 [[annotations]]
 path = "**"
 precedence = "aggregate"
-SPDX-FileCopyrightText = ["2024 SAP SE or an SAP affiliate company and Open Component Model contributors \\", "<christian.cwienk@sap.com>"]
+SPDX-FileCopyrightText = "2025 SAP SE or an SAP affiliate company and Open Component Model contributors"
 SPDX-License-Identifier = "Apache-2.0"

--- a/extension-definitions.yaml
+++ b/extension-definitions.yaml
@@ -2,7 +2,7 @@ name: delivery-dashboard
 installation:
   ocm_references:
     - helm_chart_name: delivery-dashboard
-      name: ocm.software/ocm-gear/delivery-dashboard
+      name: ocm.software/open-delivery-gear/ui
       version: 0.432.0-dev
       artefact:
         name: delivery-dashboard

--- a/src/component/bom.js
+++ b/src/component/bom.js
@@ -463,16 +463,7 @@ const ResponsiblesHeading = ({
           <Divider/>
           <Typography variant='inherit'>
             You can re-assign responsibles permanently by adding a label to
-            the corresponding resource entry in Component Descriptor,
-            exemplarily done{' '}
-            <a
-              href='https://github.com/open-component-model/delivery-dashboard/blob/master/.ocm/base-component.yaml'
-              rel='noreferrer'
-              target='_blank'
-            >
-              here
-            </a>
-            .
+            the corresponding resource entry in the OCM Component Descriptor.
           </Typography>
         </Stack>
       }

--- a/src/ocm/model.js
+++ b/src/ocm/model.js
@@ -112,7 +112,7 @@ const asKey = ({
 
 /**
  * Generates a key to uniquely identify artefact metadata `data` properties. Mirrors key defintions
- * from https://github.com/open-component-model/delivery-service/blob/master/odg/model.py.
+ * from https://github.com/open-component-model/odg-core/blob/master/odg/model.py.
  *
  * @param {String} type - artefact metadata type
  * @param {Object} data - the artefact metadata `data` payload


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/open-component-model/open-delivery-gear/issues/94

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```breaking operator
The `ocm.software/ocm-gear/delivery-dashboard` OCM component has been renamed to `ocm.software/open-delivery-gear/ui`
```
