### PR TITLE
enh(query): Use `recursive` mode by default

### DIFF
--- a/src/component/metadataBrowser.js
+++ b/src/component/metadataBrowser.js
@@ -270,7 +270,7 @@ HelpPopover.propTypes = {
 const MetadataBrowserTab = ({ component, prefill, findingCfgs = [] }) => {
   const [query, setQuery] = React.useState(buildPrefillText(prefill))
 
-  const [scopeRecursive, setScopeRecursive] = React.useState(false)
+  const [scopeRecursive, setScopeRecursive] = React.useState(true)
 
   const [rows, setRows] = React.useState(null)
   const [error, setError] = React.useState(null)


### PR DESCRIPTION
User feedback showed that most of the times the query is used in recursive mode.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```noteworthy user
Compliance query now uses "recursive" mode by default
```
