### PR TITLE
Allow rescorings to same category again

### DIFF
--- a/src/rescoring.js
+++ b/src/rescoring.js
@@ -169,10 +169,11 @@ const rescoringIdentity = (rescoring) => {
 }
 
 
-const rescoringNeedsComment = (rescoring) => {
+const rescoringNeedsComment = (rescoring, isSelected = true) => {
   return (
     rescoring.matching_rules.includes(META_RESCORING_RULES.CUSTOM_RESCORING)
     && !rescoring.comment
+    && isSelected
   )
 }
 
@@ -2668,7 +2669,7 @@ const RescoringContentTableRow = ({
             defaultValue={rescoring.comment}
             onChange={(e) => delayRescoringUpdate({comment: e.target.value})}
             onClick={(e) => e.stopPropagation()}
-            error={rescoringNeedsComment(rescoring)}
+            error={rescoringNeedsComment(rescoring, Boolean(selectedRescorings.find((r) => rescoringIdentity(r) === rescoringIdentity(rescoring))))}
             size='small'
             maxRows={4}
             InputProps={{
@@ -3439,7 +3440,7 @@ const Rescore = ({
     Apply Rescoring
   </Button>
 
-  const customRescoringsWithoutComment = rescorings.filter(rescoringNeedsComment)
+  const customRescoringsWithoutComment = rescorings.filter(r => rescoringNeedsComment(r, true))
 
   if (customRescoringsWithoutComment.length > 0) return <Tooltip
     title={
@@ -3656,8 +3657,7 @@ const RescoringModal = ({
   }, [setSprints, rescoringsForType])
 
   const allowedRescorings = filteredRescorings?.filter((rescoring) => {
-    // only rescorings are allowed iff their severity has changed OR they allow a custom due date
-    // input and the due date has changed
+    // only rescorings are allowed iff they are selected and not filtered out
     return (
       selectedRescorings.find((r) => rescoringIdentity(r) === rescoringIdentity(rescoring))
     )
@@ -3856,7 +3856,7 @@ const RescoringModal = ({
             filteredOutRescoringsLength > 0 && <Tooltip
               title={
                 `${filteredOutRescoringsLength} ${pluralise('rescoring', filteredOutRescoringsLength, 'is', 'are')}
-                filtered out or the categorisation did not change`
+                filtered out`
               }
             >
               <InfoOutlinedIcon sx={{ height: '1rem' }}/>

--- a/src/rescoring.js
+++ b/src/rescoring.js
@@ -172,10 +172,7 @@ const rescoringIdentity = (rescoring) => {
 const rescoringNeedsComment = (rescoring) => {
   return (
     rescoring.matching_rules.includes(META_RESCORING_RULES.CUSTOM_RESCORING)
-    && (
-      rescoring.severity !== rescoring.originalSeverityProposal
-      || rescoring.due_date !== rescoring.originalDueDate
-    ) && !rescoring.comment
+    && !rescoring.comment
   )
 }
 
@@ -3663,10 +3660,6 @@ const RescoringModal = ({
     // input and the due date has changed
     return (
       selectedRescorings.find((r) => rescoringIdentity(r) === rescoringIdentity(rescoring))
-      && (
-        rescoring.severity !== categoriseRescoringProposal({rescoring, findingCfg}).id
-        || rescoring.due_date !== rescoring.originalDueDate
-      )
     )
   })
   const filteredOutRescoringsLength = filteredRescorings ? selectedRescorings.length - allowedRescorings.length : 0


### PR DESCRIPTION
**What this PR does / why we need it**:
Useful to allow commenting on rescorings, without actually applying a re-rating.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```feature user
Rescorings can now be rescored to the very same category, allowing "comment-only" rescorings.
```
