### PR TITLE
chore(bom): Add deprecation note for Download BoM

### DIFF
--- a/src/util/downloadButtons.js
+++ b/src/util/downloadButtons.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Box, Button, Link } from '@mui/material'
+import { Box, Button, Link, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions } from '@mui/material'
 import CloudDownloadIcon from '@mui/icons-material/CloudDownload'
 
 import PropTypes from 'prop-types'
@@ -37,7 +37,19 @@ DownloadButton.propTypes = {
 const bomCache = {}
 
 export const DownloadBom = ({ component, ocmRepo, isLoading }) => {
-  const handleClick = async () => {
+  const [showDeprecationDialog, setShowDeprecationDialog] = React.useState(false)
+
+  const handleClick = () => {
+    setShowDeprecationDialog(true)
+  }
+
+  const handleCancelDownload = () => {
+    setShowDeprecationDialog(false)
+  }
+
+  const handleConfirmDownload = async () => {
+    setShowDeprecationDialog(false)
+
     const key = `${component.name}:${component.version}`
     if (!bomCache[key]) {
       bomCache[key] = await components.componentDependencies({
@@ -59,9 +71,26 @@ export const DownloadBom = ({ component, ocmRepo, isLoading }) => {
   }
 
   return (
-    <DownloadButton onClick={handleClick} isLoading={isLoading}>
-      download bom
-    </DownloadButton>
+    <>
+      <DownloadButton onClick={handleClick} isLoading={isLoading}>
+        download bom
+      </DownloadButton>
+
+      <Dialog open={showDeprecationDialog} onClose={handleCancelDownload}>
+        <DialogTitle>Feature Deprecation Notice</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            The Download BoM feature is deprecated and will be removed in an upcoming release.
+            Please plan to use alternative methods for accessing Bill of Materials data, such as
+            Software Bill of Materials.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button color='error' onClick={handleCancelDownload}>Cancel</Button>
+          <Button color='secondary' onClick={handleConfirmDownload}>Download Anyway</Button>
+        </DialogActions>
+      </Dialog>
+    </>
   )
 }
 DownloadBom.displayName = 'DownloadBom'


### PR DESCRIPTION
Semantically replaced by Download SBoM.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```noteworthy user
"Download BoM" (not SBoM!) button now features a deprecation notice
```
