### PR TITLE
feat(rescoring): Harmonise and fix rescoring scopes

### DIFF
--- a/src/findings.js
+++ b/src/findings.js
@@ -12,7 +12,6 @@ import {
 import {
   capitalise,
   mostSpecificRescoring,
-  orderRescoringsBySpecificity,
 } from './util'
 import { artefactMetadataFilter } from './ocm/util'
 
@@ -190,8 +189,7 @@ export const findingIsResolved = ({
 }) => {
   if (rescoring.applicable_rescorings.length === 0) return false
 
-  const rescoringsOrderedBySpecificity = orderRescoringsBySpecificity(rescoring.applicable_rescorings)
-  const id = rescoringsOrderedBySpecificity[0].data.severity
+  const id = mostSpecificRescoring(rescoring.applicable_rescorings).data.severity
   const categorisation = findCategorisationById({id, findingCfg})
 
   return categorisation.value === 0

--- a/src/rescoring.js
+++ b/src/rescoring.js
@@ -187,11 +187,11 @@ const scopedComponentArtefactId = ({
   return {
     component_name: [scopeOptions.COMPONENT, scopeOptions.ARTEFACT, scopeOptions.SINGLE].includes(scope) ? component.name : null,
     component_version: scopeOptions.SINGLE === scope && component.version !== 'greatest' ? component.version : null,
-    artefact_kind: artefactKind,
+    artefact_kind: [scopeOptions.ARTEFACT, scopeOptions.SINGLE].includes(scope) ? artefactKind : null,
     artefact: {
       artefact_name: [scopeOptions.ARTEFACT, scopeOptions.SINGLE].includes(scope) ? artefact.name : null,
       artefact_version: scopeOptions.SINGLE === scope ? artefact.version : null,
-      artefact_type: artefact.type,
+      artefact_type: [scopeOptions.ARTEFACT, scopeOptions.SINGLE].includes(scope) ? artefact.type : null,
       artefact_extra_id: scopeOptions.SINGLE === scope ? artefact.extraIdentity : {},
     },
   }

--- a/src/rescoring.js
+++ b/src/rescoring.js
@@ -184,6 +184,12 @@ const scopedComponentArtefactId = ({
   artefact,
   artefactKind,
 }) => {
+  const extraIdentity = {...artefact.extraIdentity}
+
+  if (scope === scopeOptions.ARTEFACT) {
+    delete extraIdentity.version
+  }
+
   return {
     component_name: [scopeOptions.COMPONENT, scopeOptions.ARTEFACT, scopeOptions.SINGLE].includes(scope) ? component.name : null,
     component_version: scopeOptions.SINGLE === scope && component.version !== 'greatest' ? component.version : null,
@@ -192,7 +198,7 @@ const scopedComponentArtefactId = ({
       artefact_name: [scopeOptions.ARTEFACT, scopeOptions.SINGLE].includes(scope) ? artefact.name : null,
       artefact_version: scopeOptions.SINGLE === scope ? artefact.version : null,
       artefact_type: [scopeOptions.ARTEFACT, scopeOptions.SINGLE].includes(scope) ? artefact.type : null,
-      artefact_extra_id: scopeOptions.SINGLE === scope ? artefact.extraIdentity : {},
+      artefact_extra_id: [scopeOptions.ARTEFACT, scopeOptions.SINGLE].includes(scope) ? extraIdentity : {},
     },
   }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -154,8 +154,14 @@ export const mostSpecificRescoring = (rescorings) => {
 export const filterRescoringsForFinding = (finding, rescorings) => {
   return rescorings.filter((rescoring) => {
     if (rescoring.data.referenced_type !== finding.meta.type) return false
-    if (rescoring.artefact.artefact_kind !== finding.artefact.artefact_kind) return false
-    if (rescoring.artefact.artefact.artefact_type !== finding.artefact.artefact.artefact_type) return false
+    if (
+      rescoring.artefact.artefact_kind
+      && rescoring.artefact.artefact_kind !== finding.artefact.artefact_kind
+    ) return false
+    if (
+      rescoring.artefact.artefact.artefact_type
+      && rescoring.artefact.artefact.artefact_type !== finding.artefact.artefact.artefact_type
+    ) return false
     if (
       rescoring.artefact.component_name
       && rescoring.artefact.component_name !== finding.artefact.component_name

--- a/src/util.js
+++ b/src/util.js
@@ -141,29 +141,13 @@ export const pluralise = (word, count, verbSingular, verbPlural) => {
   return `${word.replace(/y$/, 'ie')}${word.endsWith('s') ? '' : 's'}`
 }
 
-export const orderRescoringsBySpecificity = (rescorings) => {
-  return rescorings?.sort((a, b) => {
-    // if one rescoring has global scope, use the other one
-    if (a.artefact.component_name && !b.artefact.component_name) return -1
-    if (b.artefact.component_name && !a.artefact.component_name) return 1
-
-    // if one rescoring has component scope, use the other one
-    if (a.artefact.artefact.artefact_name && !b.artefact.artefact.artefact_name) return -1
-    if (b.artefact.artefact.artefact_name && !a.artefact.artefact.artefact_name) return 1
-
-    // if one rescoring has artefact scope, use the other one
-    if (a.artefact.artefact.artefact_version && !b.artefact.artefact.artefact_version) return -1
-    if (b.artefact.artefact.artefact_version && !a.artefact.artefact.artefact_version) return 1
-
-    // if both rescorings share the same scope, use the latest one
-    return new Date(b.meta.creation_date) - new Date(a.meta.creation_date)
-  })
-}
 
 export const mostSpecificRescoring = (rescorings) => {
   if (!rescorings?.length > 0) return null
 
-  return orderRescoringsBySpecificity(rescorings)[0]
+  return rescorings.sort((a, b) => {
+    return new Date(b.meta.creation_date) - new Date(a.meta.creation_date)
+  })[0]
 }
 
 

--- a/src/util.js
+++ b/src/util.js
@@ -152,6 +152,9 @@ export const mostSpecificRescoring = (rescorings) => {
 
 
 export const filterRescoringsForFinding = (finding, rescorings) => {
+  const findingExtraIdentity = {...finding.artefact.artefact.artefact_extra_id}
+  delete findingExtraIdentity.version
+
   return rescorings.filter((rescoring) => {
     if (rescoring.data.referenced_type !== finding.meta.type) return false
     if (
@@ -179,10 +182,11 @@ export const filterRescoringsForFinding = (finding, rescorings) => {
       rescoring.artefact.artefact.artefact_version
       && rescoring.artefact.artefact.artefact_version !== finding.artefact.artefact.artefact_version
     ) return false
+    const rescoringExtraIdentity = {...rescoring.artefact.artefact.artefact_extra_id}
+    delete rescoringExtraIdentity.version
     if (
-      Object.keys(rescoring.artefact.artefact.artefact_extra_id).length > 0
-      && normaliseExtraIdentity(rescoring.artefact.artefact.artefact_extra_id)
-        !== normaliseExtraIdentity(finding.artefact.artefact.artefact_extra_id)
+      Object.keys(rescoringExtraIdentity).length > 0
+      && normaliseExtraIdentity(rescoringExtraIdentity) !== normaliseExtraIdentity(findingExtraIdentity)
     ) return false
 
     if (finding.meta.type === FINDING_TYPES.VULNERABILITY) {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/open-component-model/open-delivery-gear/issues/106

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```breaking user
The latest rescoring is now always also the effective one (the specificity is not considered anymore)
```
```breaking user
The `artefact` scope will now restrict the rescoring to the exact artefact (ignoring its version). Previously, it was applied to all artefacts sharing the same name and type.
```
```other developer
An empty artefact kind and/or type is now also supported for the `component` and `global` scopes
```
```fix developer
The `version` property (if present) is now purged from the extra identity in case the `artefact` scope is used
```