### PR TITLE
fix(rescoring): Prevent duplicate rescoring fetch due to immediate re-render

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -452,7 +452,6 @@ const rescore = {
     artefactVersion,
     artefactType,
     artefactExtraId,
-    cveRescoringRuleSetName,
     types,
   }) => {
     const url = new URL(routes.rescore)
@@ -464,7 +463,6 @@ const rescore = {
       artefactVersion,
       artefactType,
       artefactExtraId: JSON.stringify(artefactExtraId),
-      cveRescoringRuleSetName,
     })
     types?.map((type) => appendPresentParams(url, {type}))
 

--- a/src/component/bom.js
+++ b/src/component/bom.js
@@ -1766,7 +1766,7 @@ const IssueChip = ({
   ocmNode,
   issueReplicatorCfg,
 }) => {
-  const ocmNodes = React.useMemo(() => [ocmNode], [ocmNode])
+  const ocmNodes = React.useMemo(() => [ocmNode], [ocmNode.identity])
   const mapping = issueReplicatorCfg.mappings.find((mapping) => ocmNode.component.name.startsWith(mapping.prefix))
 
   if (!mapping) return
@@ -1915,7 +1915,7 @@ const ComplianceCell = ({
   })
 
   const handleRescoringClose = React.useCallback(() => setMountRescoring(false), [setMountRescoring])
-  const ocmNodes = React.useMemo(() => [ocmNode], [ocmNode])
+  const ocmNodes = React.useMemo(() => [ocmNode], [ocmNode.identity])
 
   const manuallyRescorableFindingTypes = rescorableFindingTypes({findingCfgs})
 
@@ -2348,7 +2348,6 @@ const RescoringCell = ({
 
     return `${title} ${capitalise(categorisation.display_name)}`
   }
-
 
   return <Grid item onClick={(e) => e.stopPropagation()}>
     {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/open-component-model/open-delivery-gear/issues/114

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix developer
A bug where the rescoring proposals were fetched twice due to an immediate component re-render has been resolved
```
