### PR TITLE
feat(rescoring): Add rescoring for CodeQL findings

### DIFF
--- a/src/component/bom.js
+++ b/src/component/bom.js
@@ -2005,6 +2005,7 @@ const ComplianceCell = ({
   const lastMalwareScan = findLastScan(complianceFiltered, datasources.CLAMAV)
   const lastOsIdScan = findLastScan(complianceFiltered, datasources.OSID)
   const lastSastScan = findLastScan(complianceFiltered, datasources.SAST)
+  const lastCodeqlScan = findLastScan(complianceFiltered, datasources.CODEQL)
   const lastIPScan = findLastScan(complianceFiltered, datasources.BLACKDUCK)
 
   const retrieveCryptoFindings = retrieveFindingsForType({
@@ -2034,6 +2035,11 @@ const ComplianceCell = ({
   })
   const retrieveSastFindings = retrieveFindingsForType({
     findingType: FINDING_TYPES.SAST,
+    findingCfgs: findingCfgs,
+    ocmNode: ocmNode,
+  })
+  const retrieveCodeqlFindings = retrieveFindingsForType({
+    findingType: FINDING_TYPES.CODEQL,
     findingCfgs: findingCfgs,
     ocmNode: ocmNode,
   })
@@ -2125,6 +2131,19 @@ const ComplianceCell = ({
           type={FINDING_TYPES.SAST}
           categorisation={getCategorisation(FINDING_TYPES.SAST)}
           lastScan={lastSastScan}
+          findingCfgs={findingCfgs}
+          fetchComplianceSummary={fetchComplianceSummary}
+          isLoading={state.isLoading}
+        />
+      }
+      {
+        extensionsCfg?.codeql?.enabled && ocmNode.artefactKind === ARTEFACT_KIND.SOURCE && retrieveCodeqlFindings && <RescoringCell
+          ocmNodes={ocmNodes}
+          ocmRepo={ocmRepo}
+          datasource={datasources.CODEQL}
+          type={FINDING_TYPES.CODEQL}
+          categorisation={getCategorisation(FINDING_TYPES.CODEQL)}
+          lastScan={lastCodeqlScan}
           findingCfgs={findingCfgs}
           fetchComplianceSummary={fetchComplianceSummary}
           isLoading={state.isLoading}

--- a/src/consts.js
+++ b/src/consts.js
@@ -199,6 +199,7 @@ export const COMPLIANCE_TOOLS = {
   BDBA: 'bdba',
   BLACKDUCK: 'blackduck',
   CLAMAV: 'clamav',
+  CODEQL: 'codeql',
   CRYPTO: 'crypto',
   ISSUE_REPLICATOR: 'issueReplicator',
   OSID: 'osid',

--- a/src/findings.js
+++ b/src/findings.js
@@ -17,6 +17,7 @@ import { artefactMetadataFilter } from './ocm/util'
 
 
 export const FINDING_TYPES = {
+  CODEQL: 'finding/codeql',
   CRYPTO: 'finding/crypto',
   DIKI: 'finding/diki',
   FALCO: 'finding/falco',

--- a/src/ocm/model.js
+++ b/src/ocm/model.js
@@ -90,6 +90,7 @@ Object.freeze(artefactMetadataTypes)
 const datasources = {
   BDBA: 'bdba',
   CLAMAV: 'clamav',
+  CODEQL: 'codeql',
   SAST: 'sast',
   OSID: 'osid',
   CC_UTILS: 'cc-utils',
@@ -137,6 +138,10 @@ export const dataKey = ({type, data}) => {
 
   if (type === FINDING_TYPES.SAST) return asKey({
     props: [data.sast_status, data.sub_type],
+  })
+
+  if (type === FINDING_TYPES.CODEQL) return asKey({
+    props: [data.codeql_status, data.repo_url, data.language],
   })
 
   if (type === cryptoAssetTypes.ALGORITHM) return asKey({
@@ -221,6 +226,8 @@ const displayNameForData = ({
     return `${displayName} ${data.license.name}`
   } else if (type === FINDING_TYPES.SAST) {
     return `${displayName} ${data.sub_type}`
+  } else if (type === FINDING_TYPES.CODEQL) {
+    return `${displayName} ${data.language}`
   } else if (type === artefactMetadataTypes.STRUCTURE_INFO) {
     return `Package ${data.package_name} ${data.package_version}`
   } else if (type === FINDING_TYPES.CRYPTO) {

--- a/src/rescoring.js
+++ b/src/rescoring.js
@@ -1317,6 +1317,14 @@ const Subject = ({
       </div>
     </Stack>
 
+  } else if (rescoring.finding_type === FINDING_TYPES.CODEQL) {
+    return <Stack>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <Typography variant='inherit'>{finding.language}</Typography>
+        <OcmNodeDetails ocmNode={ocmNode} ocmRepo={ocmRepo} iconProps={{ sx: { height: '1rem' } }}/>
+      </div>
+    </Stack>
+
   } else if (rescoring.finding_type === FINDING_TYPES.CRYPTO) {
     return <Stack>
       <div style={{ display: 'flex', alignItems: 'center' }}>
@@ -2081,6 +2089,19 @@ const Finding = ({
         </Typography>
       </div>
       <Typography variant='inherit' marginRight='0.4rem'>{finding.sast_status}</Typography>
+    </Stack>
+
+  } else if (rescoring.finding_type === FINDING_TYPES.CODEQL) {
+    return <Stack spacing={0.5}>
+      <div style={{ display: 'flex' }}>
+        <Typography variant='inherit' marginRight='0.4rem'>Original:</Typography>
+        <Typography variant='inherit' color={`${categorisationValueToColor(categorisation.value)}.main`}>
+          {
+            categorisation.display_name
+          }
+        </Typography>
+      </div>
+      <Typography variant='inherit' marginRight='0.4rem'>{finding.codeql_status}</Typography>
     </Stack>
 
   } else if (rescoring.finding_type === FINDING_TYPES.CRYPTO) {
@@ -2860,6 +2881,17 @@ const RescoringContent = ({
       }).value,
     }
 
+    const codeqlAccesses = {
+      [orderAttributes.SUBJECT]: rescoring.finding.language,
+      [orderAttributes.FINDING]: rescoring.finding.codeql_status,
+      [orderAttributes.SPRINT]: rescoring.sprint ? new Date(rescoring.sprint.end_date) : new Date(8640000000000000),
+      [orderAttributes.CURRENT]: categoriseRescoringProposal({rescoring, findingCfg}).value,
+      [orderAttributes.RESCORED]: findCategorisationById({
+        id: rescoring.severity,
+        findingCfg: findingCfg,
+      }).value,
+    }
+
     const cryptoAccess = {
       [orderAttributes.SUBJECT]: rescoring.finding.asset?.names.sort(),
       [orderAttributes.FINDING]: `${FINDING_TYPES.CRYPTO}_${rescoring.finding.standard}_${rescoring.finding.asset?.asset_type}`,
@@ -2913,6 +2945,8 @@ const RescoringContent = ({
       return malwareAccess[desired]
     } else if (rescoringType === FINDING_TYPES.SAST) {
       return sastAccesses[desired]
+    } else if (rescoringType === FINDING_TYPES.CODEQL) {
+      return codeqlAccesses[desired]
     } else if (rescoringType === FINDING_TYPES.CRYPTO) {
       return cryptoAccess[desired]
     } else if (rescoringType === FINDING_TYPES.DIKI) {
@@ -3350,6 +3384,12 @@ const Rescore = ({
         return {
           sast_status: rescoring.finding.sast_status,
           sub_type: rescoring.finding.sub_type,
+        }
+      } else if (type === FINDING_TYPES.CODEQL) {
+        return {
+          codeql_status: rescoring.finding.codeql_status,
+          repo_url: rescoring.finding.repo_url,
+          language: rescoring.finding.language,
         }
       } else if (type === FINDING_TYPES.CRYPTO) {
         return {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
```
Here's a summary of what was added across 3 files:

src/findings.js — added CODEQL: 'finding/codeql' to FINDING_TYPES.

src/ocm/model.js — three additions:

CODEQL: 'codeql' in datasources
dataKey branch: keys on [codeql_status, repo_url, language] (mirrors the Python CodeqlFinding.key)
displayNameForData branch: shows the language name (e.g. "Codeql Go")
[src/rescoring.js](vscode-webview://1ehcnf3qevpuqd0v3b8omiqanmkdfa1kgav8b6a60rlicujshlqq/src/rescoring.js) — four additions, each following the SAST pattern:

Subject column: shows finding.language with the OCM node details icon
Finding column: shows original severity + finding.codeql_status
Sort-access object (codeqlAccesses): subjects on language, finding key on codeql_status
serialiseRescoring: serialises { codeql_status, repo_url, language } as the finding identity payload (matches RescoreCodeqlFinding in the backend model)
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```feature user
Added support for CodeQL extension and findings in ODG UI (rescoring & monitoring)
```
