### PR TITLE
fix(ocm): Check supported artefact types only for matching prefix

### DIFF
--- a/src/util/sbomDownloadPopover.js
+++ b/src/util/sbomDownloadPopover.js
@@ -54,7 +54,7 @@ const isResourceSupported = (resource) => {
   const artefactType = resource?.type
 
   if (accessType && !SUPPORTED_ACCESS_TYPES.includes(accessType)) return false
-  if (artefactType && !SUPPORTED_ARTEFACT_TYPES.includes(artefactType)) return false
+  if (artefactType && !SUPPORTED_ARTEFACT_TYPES.find((type) => artefactType.startsWith(type))) return false
 
   return true
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Required to support variants like `application/tar+vm-image-rootfs` instead of `application/tar`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/open-component-model/open-delivery-gear/issues/205

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator

```
